### PR TITLE
Add codemirror focus event, display hint on focus

### DIFF
--- a/src_editor/CodeMirror.re
+++ b/src_editor/CodeMirror.re
@@ -202,4 +202,9 @@ module Editor = {
   external onChange :
     (editor, [@bs.as "change"] _, (editor, EditorChange.t) => unit) => unit =
     "on";
+
+  [@bs.send]
+  external onFocus :
+    (editor, [@bs.as "focus"] _, (editor, Dom.event) => unit) => unit =
+    "on";
 };

--- a/src_editor/Editor_CodeBlock.re
+++ b/src_editor/Editor_CodeBlock.re
@@ -14,7 +14,15 @@ let getEditor = (state, ~default, ~f) =>
   };
 
 let make =
-    (~value, ~firstLineNumber, ~widgets, ~onChange, ~onExecute, _children)
+    (
+      ~value,
+      ~firstLineNumber,
+      ~widgets,
+      ~onChange,
+      ~onFocus,
+      ~onExecute,
+      _children,
+    )
     : ReasonReact.component(state, _, unit) => {
   ...component,
   initialState: () => {
@@ -118,6 +126,7 @@ let make =
     <Editor_CodeMirror
       value
       onChange
+      onFocus
       setEditor=(
         editor => {
           state.editor := Some(editor);

--- a/src_editor/Editor_CodeMirror.re
+++ b/src_editor/Editor_CodeMirror.re
@@ -38,6 +38,7 @@ let make =
       ~options: CodeMirror.EditorConfiguration.t,
       ~setEditor: option(CodeMirror.editor => unit)=?,
       ~onChange=?,
+      ~onFocus=?,
       _children,
     )
     : ReasonReact.component(state, _, unit) => {
@@ -80,6 +81,15 @@ let make =
            };
            /* }; */
          });
+
+      editor
+      |. CodeMirror.Editor.onFocus((_editor, _event) =>
+           switch (onFocus) {
+           | None => ()
+           | Some(onFocus) => onFocus()
+           }
+         );
+
       state.editor := Some(editor);
       %bs.raw
       {|window.editor = editor|};


### PR DESCRIPTION
If no code block has been focused, the last code block has the hint and otherwise the code block which has most recently been focused.

Fixes #17.