### PR TITLE
Use ArrowUp and ArrowDown key for moving between blocks

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -28,7 +28,7 @@
     "reason-react",
     "bs-css",
     "@glennsl/bs-json",
-    "@thangngoc89/ocaml-re"
+    "bs-webapi"
   ],
   "bs-dev-dependencies": ["@glennsl/bs-jest"],
   "refmt": 3,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1940,6 +1940,11 @@
       "integrity": "sha1-VEtYwqUymc9Aa1dHfgY4nkratCE=",
       "dev": true
     },
+    "bs-webapi": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/bs-webapi/-/bs-webapi-0.10.0.tgz",
+      "integrity": "sha512-CnEwtcN89JjsJQcaTRqkuHFGFrWka21miEvZPgbnmmDox1XYcrtXgsRD5S1EM3002F88BgX4Ek0kGHPOq6COQA=="
+    },
     "bser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
@@ -4400,14 +4405,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4422,20 +4425,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4552,8 +4552,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4565,7 +4564,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4580,7 +4578,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4588,14 +4585,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4614,7 +4609,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4695,8 +4689,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4708,7 +4701,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4830,7 +4822,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@thangngoc89/ocaml-re": "^1.0.0",
     "bs-css": "^7.0.1",
     "bs-json": "^1.0.1",
+    "bs-webapi": "^0.10.0",
     "codemirror": "^5.39.2",
     "comlink": "^3.0.3",
     "install": "^0.12.1",

--- a/src_editor/CodeMirror.re
+++ b/src_editor/CodeMirror.re
@@ -134,6 +134,7 @@ module Position = {
   type t = {
     ch: int,
     line: int,
+    sticky: Js.Nullable.t(string),
   };
 };
 
@@ -143,7 +144,7 @@ module LineWidget = {
     Removes the widget.
   */ [@bs.send] external clear : t => unit = "";
   /** Call this if you made some change to the widget's DOM node that might affect its height.
-        It'll force CodeMirror to update the height of the line that contains the widget. */
+  It'll force CodeMirror to update the height of the line that contains the widget. */
   [@bs.send]
   external changed : t => unit = "";
   [@bs.deriving abstract]
@@ -175,8 +176,23 @@ module EditorChange = {
   };
 };
 
+module Doc = {
+  type t;
+
+  /** start is a an optional string indicating which end of the selection to return.
+    It may be "start" , "end" , "head"(the side of the selection that moves when you press shift + arrow),
+    or "anchor"(the fixed side of the selection).
+    Omitting the argument is the same as passing "head".A { line , ch } object will be returned.
+  */
+  [@bs.send]
+  external getCursor :
+    (t, [@bs.string] [ | `start | [@bs.as "end"] `end_ | `head | `anchor]) =>
+    Position.t =
+    "";
+};
+
 module Editor = {
-  [@bs.send] external getValue : (editor, unit) => string = "";
+  [@bs.send] external getValue : editor => string = "";
   [@bs.send] external setValue : (editor, string) => unit = "";
   [@bs.send] external setOption : (editor, string, 'a) => unit = "";
   [@bs.send] external getOption : (editor, string) => 'a = "";
@@ -198,6 +214,13 @@ module Editor = {
     LineWidget.t =
     "";
 
+  [@bs.send] external getDoc : editor => Doc.t = "";
+  [@bs.send] external hasFocus : editor => bool = "";
+  [@bs.send] external focus : editor => unit = "";
+
+  [@bs.send] external getLine : (editor, int) => string = "";
+  [@bs.send] external lineCount : editor => int = "";
+
   [@bs.send]
   external onChange :
     (editor, [@bs.as "change"] _, (editor, EditorChange.t) => unit) => unit =
@@ -206,5 +229,10 @@ module Editor = {
   [@bs.send]
   external onFocus :
     (editor, [@bs.as "focus"] _, (editor, Dom.event) => unit) => unit =
+    "on";
+
+  [@bs.send]
+  external onKeydown :
+    (editor, [@bs.as "keydown"] _, (editor, Dom.keyboardEvent) => unit) => unit =
     "on";
 };

--- a/src_editor/CodeMirror.re
+++ b/src_editor/CodeMirror.re
@@ -77,8 +77,7 @@ module EditorConfiguration = {
     dragDrop: bool,
     [@bs.optional] /** When given , this will be called when the editor is handling a dragenter , dragover , or drop event.
         It will be passed the editor instance and the event object as arguments.
-        The callback can choose to handle the event itself , in which case it should return true to indicate that CodeMirror should not do anything further. */ /* TODO */ /* onDragEvent?: (instance: CodeMirror.Editor, event: Event) => boolean; */
-                                                                    /** This provides a rather low - level hook into CodeMirror's key handling.
+        The callback can choose to handle the event itself , in which case it should return true to indicate that CodeMirror should not do anything further. */ /* TODO */ /* onDragEvent?: (instance: CodeMirror.Editor, event: Event) => boolean; */ /** This provides a rather low - level hook into CodeMirror's key handling.
         If provided, this function will be called on every keydown, keyup, and keypress event that CodeMirror captures.
         It will be passed two arguments, the editor instance and the key event.
         This key event is pretty much the raw key event, except that a stop() method is always added to it.
@@ -134,8 +133,10 @@ module Position = {
   type t = {
     ch: int,
     line: int,
+    [@bs.optional]
     sticky: Js.Nullable.t(string),
   };
+  let make = t;
 };
 
 module LineWidget = {
@@ -189,6 +190,8 @@ module Doc = {
     (t, [@bs.string] [ | `start | [@bs.as "end"] `end_ | `head | `anchor]) =>
     Position.t =
     "";
+
+  [@bs.send] external setCursor : (t, Position.t) => unit = "";
 };
 
 module Editor = {

--- a/src_editor/Editor_CodeBlock.re
+++ b/src_editor/Editor_CodeBlock.re
@@ -16,10 +16,13 @@ let getEditor = (state, ~default, ~f) =>
 let make =
     (
       ~value,
+      ~focused,
       ~firstLineNumber,
       ~widgets,
       ~onChange,
       ~onFocus,
+      ~onBlockUp=?,
+      ~onBlockDown=?,
       ~onExecute,
       _children,
     )
@@ -125,8 +128,11 @@ let make =
   render: ({state}) =>
     <Editor_CodeMirror
       value
+      focused
       onChange
       onFocus
+      ?onBlockUp
+      ?onBlockDown
       setEditor=(
         editor => {
           state.editor := Some(editor);

--- a/src_editor/Editor_CodeMirror.re
+++ b/src_editor/Editor_CodeMirror.re
@@ -18,6 +18,7 @@ type state = {
   editor: ref(option(CodeMirror.editor)),
   divRef: ref(option(Dom.element)),
   value: string,
+  focused: bool,
 };
 
 let setDivRef = (theRef, {ReasonReact.state}) =>
@@ -35,26 +36,40 @@ let make =
     (
       ~className=?,
       ~value,
+      ~focused: bool,
       ~options: CodeMirror.EditorConfiguration.t,
       ~setEditor: option(CodeMirror.editor => unit)=?,
+      ~onBlockUp: option(unit => unit)=?,
+      ~onBlockDown: option(unit => unit)=?,
       ~onChange=?,
       ~onFocus=?,
       _children,
     )
     : ReasonReact.component(state, _, unit) => {
   ...component,
-  initialState: () => {editor: ref(None), divRef: ref(None), value},
+  initialState: () => {
+    editor: ref(None),
+    divRef: ref(None),
+    value,
+    focused,
+  },
   willReceiveProps: ({state}) =>
     getEditor(state, ~default=state, ~f=editor =>
       {
         ...state,
         value: {
           if (state.value != value
-              && value != (editor |. CodeMirror.Editor.getValue())) {
+              && value != (editor |. CodeMirror.Editor.getValue)) {
             editor |. CodeMirror.Editor.setValue(value);
           };
-
           value;
+        },
+        focused: {
+          if (state.focused != focused
+              && focused != (editor |. CodeMirror.Editor.hasFocus)) {
+            editor |. CodeMirror.Editor.focus;
+          };
+          focused;
         },
       }
     ),
@@ -69,26 +84,48 @@ let make =
       };
       editor |. CodeMirror.Editor.setValue(value);
 
-      editor
-      |. CodeMirror.Editor.onChange((editor, diff) => {
-           Js.log(diff);
-           let currentEditorValue = editor |. CodeMirror.Editor.getValue();
-           /* TODO: Figure out why this behaves differently from JS version */
-           /* if (currentEditorValue != value) { */
-           switch (onChange) {
-           | None => ()
-           | Some(onChange) => onChange(currentEditorValue)
-           };
-           /* }; */
-         });
+      switch (onChange) {
+      | None => ()
+      | Some(onChange) =>
+        editor
+        |. CodeMirror.Editor.onChange((editor, diff) => {
+             Js.log(diff);
+             let currentEditorValue = editor |. CodeMirror.Editor.getValue;
+             onChange(currentEditorValue);
+           })
+      };
 
-      editor
-      |. CodeMirror.Editor.onFocus((_editor, _event) =>
-           switch (onFocus) {
-           | None => ()
-           | Some(onFocus) => onFocus()
-           }
-         );
+      switch (onFocus) {
+      | None => ()
+      | Some(onFocus) =>
+        editor |. CodeMirror.Editor.onFocus((_editor, _event) => onFocus())
+      };
+
+      switch (onBlockUp, onBlockDown) {
+      | (Some(onBlockUp), Some(onBlockDown)) =>
+        editor
+        |. CodeMirror.Editor.onKeydown((editor, event) => {
+             open CodeMirror.Position;
+             let doc = editor |. CodeMirror.Editor.getDoc;
+             let cursor = doc |. CodeMirror.Doc.getCursor(`head);
+             switch (event |. Webapi.Dom.KeyboardEvent.key) {
+             | "ArrowUp" when cursor |. lineGet == 0 && cursor |. chGet == 0 =>
+               onBlockUp()
+             | "ArrowDown" =>
+               let lastLine = (editor |. CodeMirror.Editor.lineCount) - 1;
+               let lastChar =
+                 editor
+                 |. CodeMirror.Editor.getLine(lastLine)
+                 |. Js.String.length;
+               if (lineGet(cursor) == lastLine
+                   && lastChar == (cursor |. chGet)) {
+                 onBlockDown();
+               };
+             | _ => ()
+             };
+           })
+      | _ => ()
+      };
 
       state.editor := Some(editor);
       %bs.raw

--- a/src_editor/Editor_Entry.re
+++ b/src_editor/Editor_Entry.re
@@ -4,7 +4,7 @@ let component = ReasonReact.statelessComponent("Editor_Entry");
 
 let code = [|
   Editor_Loremipsum.code1,
-  /* Editor_Loremipsum.code2, */
+  Editor_Loremipsum.code2,
   /* Editor_Loremipsum.code3, */
 |];
 

--- a/src_editor/Editor_Page.re
+++ b/src_editor/Editor_Page.re
@@ -5,7 +5,7 @@ open Editor_Types.Block;
 
 type state = {
   blocks: array(block),
-  focusedBlock: option(id),
+  focusedBlock: option((id, focusChangeType)),
 };
 
 type action =
@@ -142,12 +142,15 @@ let make = (~blocks: array(block), _children) => {
         focusedBlock:
           switch (state.focusedBlock) {
           | None => None
-          | Some(focusedBlock) =>
-            focusedBlock == blockId ? None : Some(focusedBlock)
+          | Some((focusedBlock, _)) =>
+            focusedBlock == blockId ? None : state.focusedBlock
           },
       })
     | Block_Focus(blockId) =>
-      ReasonReact.Update({...state, focusedBlock: Some(blockId)})
+      ReasonReact.Update({
+        ...state,
+        focusedBlock: Some((blockId, FcTyp_EditorFocus)),
+      })
     | Block_Add(afterBlockId, blockType) =>
       ReasonReact.Update({
         ...state,
@@ -190,7 +193,10 @@ let make = (~blocks: array(block), _children) => {
       switch (upperBlockId) {
       | None => ReasonReact.NoUpdate
       | Some(upperBlockId) =>
-        ReasonReact.Update({...state, focusedBlock: Some(upperBlockId)})
+        ReasonReact.Update({
+          ...state,
+          focusedBlock: Some((upperBlockId, FcTyp_BlockFocusUp)),
+        })
       };
     | Block_FocusDown(blockId) =>
       let lowerBlockId = {
@@ -211,7 +217,10 @@ let make = (~blocks: array(block), _children) => {
       switch (lowerBlockId) {
       | None => ReasonReact.NoUpdate
       | Some(lowerBlockId) =>
-        ReasonReact.Update({...state, focusedBlock: Some(lowerBlockId)})
+        ReasonReact.Update({
+          ...state,
+          focusedBlock: Some((lowerBlockId, FcTyp_BlockFocusDown)),
+        })
       };
     },
   render: ({send, state}) => {
@@ -228,8 +237,8 @@ let make = (~blocks: array(block), _children) => {
                      value=bc_value
                      focused=(
                        switch (state.focusedBlock) {
-                       | None => false
-                       | Some(id) => id == b_id
+                       | None => None
+                       | Some((id, typ)) => id == b_id ? Some(typ) : None
                        }
                      )
                      onChange=(
@@ -258,7 +267,7 @@ let make = (~blocks: array(block), _children) => {
                            last_b_id == b_id ?
                              blockHint(b_id, send) : ReasonReact.null
                        )
-                     | Some(focusedBlock) =>
+                     | Some((focusedBlock, _)) =>
                        focusedBlock == b_id ?
                          blockHint(b_id, send) : ReasonReact.null
                      }
@@ -272,8 +281,8 @@ let make = (~blocks: array(block), _children) => {
                      value=text
                      focused=(
                        switch (state.focusedBlock) {
-                       | None => false
-                       | Some(id) => id == b_id
+                       | None => None
+                       | Some((id, typ)) => id == b_id ? Some(typ) : None
                        }
                      )
                      onFocus=(() => send(Block_Focus(b_id)))

--- a/src_editor/Editor_Page.re
+++ b/src_editor/Editor_Page.re
@@ -220,72 +220,75 @@ let make = (~blocks: array(block), _children) => {
       (
         state.blocks
         |. Belt.Array.mapU((. {b_id, b_data}) =>
-             <div key=b_id id=b_id className="cell__container">
-               (
-                 switch (b_data) {
-                 | B_Code({bc_value, bc_widgets, bc_firstLineNumber}) =>
-                   <div className="source-editor">
-                     <Editor_CodeBlock
-                       value=bc_value
-                       focused=(
-                         switch (state.focusedBlock) {
-                         | None => false
-                         | Some(id) => id == b_id
-                         }
-                       )
-                       onChange=(
-                         newValue => send(Block_UpdateValue(b_id, newValue))
-                       )
-                       onExecute=(() => send(Block_Execute(b_id)))
-                       onFocus=(() => send(Block_Focus(b_id)))
-                       onBlockUp=(() => send(Block_FocusUp(b_id)))
-                       onBlockDown=(() => send(Block_FocusDown(b_id)))
-                       widgets=bc_widgets
-                       firstLineNumber=bc_firstLineNumber
-                     />
-                   </div>
-                 | B_Text(text) =>
-                   <div className="text-editor">
-                     <Editor_TextBlock
-                       value=text
-                       focused=(
-                         switch (state.focusedBlock) {
-                         | None => false
-                         | Some(id) => id == b_id
-                         }
-                       )
-                       onFocus=(() => send(Block_Focus(b_id)))
-                       onBlockUp=(() => send(Block_FocusUp(b_id)))
-                       onBlockDown=(() => send(Block_FocusDown(b_id)))
-                       onChange=(
-                         newValue => send(Block_UpdateValue(b_id, newValue))
-                       )
-                     />
-                   </div>
-                 }
-               )
-               <div className="cell__controls">
-                 (blockControlsButtons(b_id, send))
-                 (
-                   /*
-                    Display hint on focusedBlock or last CodeBlock
-                    If there are no CodeBlock then don't display anything
-                    */
-                   switch (state.focusedBlock) {
-                   | None =>
-                     lastCodeBlockId
-                     =>> (
-                       last_b_id =>
-                         last_b_id == b_id ?
-                           blockHint(b_id, send) : ReasonReact.null
+             switch (b_data) {
+             | B_Code({bc_value, bc_widgets, bc_firstLineNumber}) =>
+               <div key=b_id id=b_id className="cell__container">
+                 <div className="source-editor">
+                   <Editor_CodeBlock
+                     value=bc_value
+                     focused=(
+                       switch (state.focusedBlock) {
+                       | None => false
+                       | Some(id) => id == b_id
+                       }
                      )
-                   | Some(focusedBlock) =>
-                     focusedBlock == b_id ?
-                       blockHint(b_id, send) : ReasonReact.null
-                   }
-                 )
+                     onChange=(
+                       newValue => send(Block_UpdateValue(b_id, newValue))
+                     )
+                     onExecute=(() => send(Block_Execute(b_id)))
+                     onFocus=(() => send(Block_Focus(b_id)))
+                     onBlockUp=(() => send(Block_FocusUp(b_id)))
+                     onBlockDown=(() => send(Block_FocusDown(b_id)))
+                     widgets=bc_widgets
+                     firstLineNumber=bc_firstLineNumber
+                   />
+                 </div>
+                 <div className="cell__controls">
+                   (blockControlsButtons(b_id, send))
+                   (
+                     /*
+                      Display hint on focusedBlock or last CodeBlock
+                      If there are no CodeBlock then don't display anything
+                      */
+                     switch (state.focusedBlock) {
+                     | None =>
+                       lastCodeBlockId
+                       =>> (
+                         last_b_id =>
+                           last_b_id == b_id ?
+                             blockHint(b_id, send) : ReasonReact.null
+                       )
+                     | Some(focusedBlock) =>
+                       focusedBlock == b_id ?
+                         blockHint(b_id, send) : ReasonReact.null
+                     }
+                   )
+                 </div>
                </div>
-             </div>
+             | B_Text(text) =>
+               <div key=b_id id=b_id className="cell__container">
+                 <div className="text-editor">
+                   <Editor_TextBlock
+                     value=text
+                     focused=(
+                       switch (state.focusedBlock) {
+                       | None => false
+                       | Some(id) => id == b_id
+                       }
+                     )
+                     onFocus=(() => send(Block_Focus(b_id)))
+                     onBlockUp=(() => send(Block_FocusUp(b_id)))
+                     onBlockDown=(() => send(Block_FocusDown(b_id)))
+                     onChange=(
+                       newValue => send(Block_UpdateValue(b_id, newValue))
+                     )
+                   />
+                 </div>
+                 <div className="cell__controls">
+                   (blockControlsButtons(b_id, send))
+                 </div>
+               </div>
+             }
            )
         |. ReasonReact.array
       )

--- a/src_editor/Editor_TextBlock.re
+++ b/src_editor/Editor_TextBlock.re
@@ -9,14 +9,26 @@ let getEditor = (state, ~default, ~f) =>
   };
 
 let make =
-    (~value, ~onChange, _children)
+    (
+      ~value,
+      ~focused,
+      ~onChange,
+      ~onFocus,
+      ~onBlockUp=?,
+      ~onBlockDown=?,
+      _children,
+    )
     : ReasonReact.component(state, _, unit) => {
   ...component,
   initialState: () => {editor: ref(None)},
   render: ({state}) =>
     <Editor_CodeMirror
       value
+      focused
       onChange
+      onFocus
+      ?onBlockUp
+      ?onBlockDown
       setEditor=(
         editor => {
           state.editor := Some(editor);

--- a/src_editor/Editor_Types.re
+++ b/src_editor/Editor_Types.re
@@ -7,13 +7,17 @@ module Block = {
 
   type id = string;
 
-  type blockType =
+  type blockData =
     | B_Code(bcode)
     | B_Text(string);
 
+  type blockTyp =
+    | BTyp_Code
+    | BTyp_Text;
+
   type block = {
     b_id: id,
-    b_data: blockType,
+    b_data: blockData,
   };
 
   type focusChangeType =

--- a/src_editor/Editor_Types.re
+++ b/src_editor/Editor_Types.re
@@ -6,6 +6,7 @@ module Block = {
   };
 
   type id = string;
+
   type blockType =
     | B_Code(bcode)
     | B_Text(string);
@@ -14,4 +15,9 @@ module Block = {
     b_id: id,
     b_data: blockType,
   };
+
+  type focusChangeType =
+    | FcTyp_EditorFocus
+    | FcTyp_BlockFocusUp
+    | FcTyp_BlockFocusDown;
 };


### PR DESCRIPTION
Fixes #9 
cc @matthiaskern 

This is an early preview of that functionality. I want to discuss a about UX before merging this. 
Currently, when calling `editor.focus()`, CodeMirror will put cursor at last focus position. Do you thing that would be annoying? Do we need to adjust cursor position as well? (put cursor at (0, 0) in next block on ArrowDown and (lastLine, lastChar) in previous block on ArrowUp)

You can see the this PR in production here: https://rtop-frxlpjtusg.now.sh

---

Note to self:

to set cursor at the end of existing content: `cmInstance.setCursor(cmInstance.lineCount(), 0);`