### PR TITLE
CodeBlock: Remove widgets below editing lines

### DIFF
--- a/client/src_editor/Editor_CodeBlock.re
+++ b/client/src_editor/Editor_CodeBlock.re
@@ -63,9 +63,10 @@ let make =
                    (. acc, w) => {
                      open Editor_CodeBlockTypes.Widget;
                      open Editor_CodeBlockLineWidget;
+                     let {lw_line: line, lw_data} = w;
                      let newLineWidget =
-                       switch (w) {
-                       | Lw_Error({content, line}) =>
+                       switch (lw_data) {
+                       | Lw_Error(content) =>
                          editor
                          |. CodeMirror.Editor.addLineWidget(
                               ~line,
@@ -78,7 +79,7 @@ let make =
                                   ~showIfHidden=false,
                                 ),
                             )
-                       | Lw_Warning({content, line}) =>
+                       | Lw_Warning(content) =>
                          editor
                          |. CodeMirror.Editor.addLineWidget(
                               ~line,
@@ -91,7 +92,7 @@ let make =
                                   ~showIfHidden=false,
                                 ),
                             )
-                       | Lw_Value({content, line}) =>
+                       | Lw_Value(content) =>
                          editor
                          |. CodeMirror.Editor.addLineWidget(
                               ~line,
@@ -104,7 +105,7 @@ let make =
                                   ~showIfHidden=false,
                                 ),
                             )
-                       | Lw_Stdout({content, line}) =>
+                       | Lw_Stdout(content) =>
                          editor
                          |. CodeMirror.Editor.addLineWidget(
                               ~line,

--- a/client/src_editor/Editor_CodeBlockTypes.re
+++ b/client/src_editor/Editor_CodeBlockTypes.re
@@ -1,11 +1,11 @@
 module Widget = {
-  type t =
-    | Lw_Error(widgetContent)
-    | Lw_Warning(widgetContent)
-    | Lw_Value(widgetContent)
-    | Lw_Stdout(widgetContent)
-  and widgetContent = {
-    content: string,
-    line: int,
+  type lineWidgetData =
+    | Lw_Error(string)
+    | Lw_Warning(string)
+    | Lw_Value(string)
+    | Lw_Stdout(string);
+  type t = {
+    lw_line: int,
+    lw_data: lineWidgetData,
   };
 };

--- a/client/src_editor/Editor_CodeMirror.re
+++ b/client/src_editor/Editor_CodeMirror.re
@@ -103,9 +103,8 @@ let make =
       | Some(onChange) =>
         editor
         |. CodeMirror.Editor.onChange((editor, diff) => {
-             Js.log(diff);
              let currentEditorValue = editor |. CodeMirror.Editor.getValue;
-             onChange(currentEditorValue);
+             onChange(currentEditorValue, diff);
            })
       };
 


### PR DESCRIPTION
This will remove all evaluated result below the editing line. So no stale results are available