### PR TITLE
Evaluate all code blocks below current block with same scope

### DIFF
--- a/client/src_analyzer/Worker_Analyze.re
+++ b/client/src_analyzer/Worker_Analyze.re
@@ -186,7 +186,7 @@ module Make = (ESig: Worker_Evaluator.EvaluatorSig) => {
               }
             )
        );
-  let execute: (. bool, string) => list(Worker_Types.blockData) =
+  let execute: (. bool, string) => list(blockData) =
     (. reset, code) => {
       if (reset) {
         Evaluator.reset();
@@ -212,5 +212,13 @@ module Make = (ESig: Worker_Evaluator.EvaluatorSig) => {
              };
            });
       result;
+    };
+
+  let executeMany:
+    (. Belt.Map.String.t(string)) => Belt.Map.String.t(list(blockData)) =
+    (. codeMap) => {
+      /* Reset before evaluating several blocks */
+      Evaluator.reset();
+      codeMap |. Belt.Map.String.map(code => execute(. false, code));
     };
 };

--- a/client/src_analyzer/Worker_Index.re
+++ b/client/src_analyzer/Worker_Index.re
@@ -5,6 +5,6 @@ Worker.importScripts("/reason.js");
 
 module Analyze = Worker_Analyze.Make(Worker_BrowserEvaluator);
 
-let obj = {"execute": Analyze.execute};
+let obj = {"execute": Analyze.execute, "executeMany": Analyze.executeMany};
 
 Comlink.(comlink |. expose(obj, Worker.self));

--- a/client/src_editor/Editor_Blocks.re
+++ b/client/src_editor/Editor_Blocks.re
@@ -10,7 +10,7 @@ type state = {
 
 type action =
   | Block_Add(id, blockData)
-  | Block_Execute(id)
+  | Block_Execute
   | Block_Delete(id)
   | Block_Focus(id, blockTyp)
   | Block_Blur(id)
@@ -38,11 +38,10 @@ let blockControlsButtons = (b_id, send) =>
     </button>
   </div>;
 
-let blockHint = (b_id, send) =>
+let blockHint = send =>
   <div className="cell__controls-hint">
     <button
-      onClick=(_ => send(Block_Execute(b_id)))
-      className="cell__controls-hint--run">
+      onClick=(_ => send(Block_Execute)) className="cell__controls-hint--run">
       ("run" |. str)
     </button>
     <span>
@@ -59,8 +58,7 @@ let make = (~blocks: array(block), _children) => {
   ...component,
   initialState: () => {blocks, focusedBlock: None},
   didMount: self => {
-    blocks
-    |. Belt.Array.forEachU((. {b_id}) => self.send(Block_Execute(b_id)));
+    self.send(Block_Execute);
     ();
   },
   reducer: (action, state) =>
@@ -85,34 +83,38 @@ let make = (~blocks: array(block), _children) => {
                };
              }),
       })
-    | Block_Execute(blockId) =>
-      let block = state.blocks |. arrayFind(({b_id}) => b_id == blockId);
-      switch (block) {
-      | None => ReasonReact.NoUpdate
-      | Some(block) =>
-        switch (block.b_data) {
-        | B_Text(_) => ReasonReact.NoUpdate
-        | B_Code({bc_value}) =>
-          ReasonReact.SideEffects(
-            (
-              self =>
-                Js.Promise.(
-                  Editor_Worker.execute(. true, bc_value)
-                  |> then_(result => {
-                       let widgets =
-                         Editor_Blocks_Utils.executeRessultToWidget(result);
-                       resolve(
-                         self.send(Block_AddWidgets(blockId, widgets)),
-                       );
-                     })
-                  |> catch(error => resolve(Js.log(error)))
-                  |> ignore
-                )
-            ),
-          )
-        }
-      };
+    | Block_Execute =>
+      module MS = Belt.Map.String;
 
+      let allCodeBlocks =
+        state.blocks
+        |. Belt.Array.reduceU(MS.empty, (. map, {b_id, b_data}) =>
+             switch (b_data) {
+             | B_Text(_) => map
+             | B_Code({bc_value}) => map |. MS.set(b_id, bc_value)
+             }
+           );
+
+      ReasonReact.SideEffects(
+        (
+          self =>
+            Js.Promise.(
+              Editor_Worker.executeMany(. allCodeBlocks)
+              |> then_(results => {
+                   results
+                   |. MS.forEachU((. blockId, result) => {
+                        let widgets =
+                          Editor_Blocks_Utils.executeResultToWidget(result);
+                        self.send(Block_AddWidgets(blockId, widgets));
+                      });
+
+                   resolve();
+                 })
+              |> catch(error => resolve(Js.log(error)))
+              |> ignore
+            )
+        ),
+      );
     | Block_UpdateValue(blockId, newValue, diff) =>
       ReasonReact.Update({
         ...state,
@@ -199,7 +201,7 @@ let make = (~blocks: array(block), _children) => {
           |. Editor_Blocks_Utils.syncLineNumber,
       })
     | Block_FocusUp(blockId) =>
-      let upperBlockId = {
+      let upperBlock = {
         let rec loop = i =>
           if (i >= 0) {
             let {b_id} = state.blocks[i];
@@ -217,7 +219,7 @@ let make = (~blocks: array(block), _children) => {
           };
         loop((state.blocks |. Belt.Array.length) - 1);
       };
-      switch (upperBlockId) {
+      switch (upperBlock) {
       | None => ReasonReact.NoUpdate
       | Some((upperBlockId, blockTyp)) =>
         ReasonReact.Update({
@@ -226,7 +228,7 @@ let make = (~blocks: array(block), _children) => {
         })
       };
     | Block_FocusDown(blockId) =>
-      let lowerBlockId = {
+      let lowerBlock = {
         let length = state.blocks |. Belt.Array.length;
         let rec loop = i =>
           if (i < length) {
@@ -245,7 +247,7 @@ let make = (~blocks: array(block), _children) => {
           };
         loop(0);
       };
-      switch (lowerBlockId) {
+      switch (lowerBlock) {
       | None => ReasonReact.NoUpdate
       | Some((lowerBlockId, blockTyp)) =>
         ReasonReact.Update({
@@ -277,7 +279,7 @@ let make = (~blocks: array(block), _children) => {
                        (newValue, diff) =>
                          send(Block_UpdateValue(b_id, newValue, diff))
                      )
-                     onExecute=(() => send(Block_Execute(b_id)))
+                     onExecute=(() => send(Block_Execute))
                      onFocus=(() => send(Block_Focus(b_id, BTyp_Code)))
                      onBlur=(() => send(Block_Blur(b_id)))
                      onBlockUp=(() => send(Block_FocusUp(b_id)))
@@ -296,13 +298,13 @@ let make = (~blocks: array(block), _children) => {
                      switch (state.focusedBlock) {
                      | Some((focusedBlock, BTyp_Code, _)) =>
                        focusedBlock == b_id ?
-                         blockHint(b_id, send) : ReasonReact.null
+                         blockHint(send) : ReasonReact.null
                      | _ =>
                        lastCodeBlockId
                        =>> (
                          last_b_id =>
                            last_b_id == b_id ?
-                             blockHint(b_id, send) : ReasonReact.null
+                             blockHint(send) : ReasonReact.null
                        )
                      }
                    )

--- a/client/src_editor/Editor_Blocks_Utils.re
+++ b/client/src_editor/Editor_Blocks_Utils.re
@@ -10,7 +10,7 @@ let renderErrorIndicator = (colStart, colEnd, content) =>
   ++ "\n"
   ++ content;
 
-let executeRessultToWidget = (result: list(Worker_Types.blockData)) => {
+let executeResultToWidget = (result: list(Worker_Types.blockData)) => {
   open Worker_Types;
   open Editor_CodeBlockTypes;
 

--- a/client/src_editor/Editor_Worker.re
+++ b/client/src_editor/Editor_Worker.re
@@ -15,13 +15,14 @@ type js_executeResult = {
 [@bs.deriving abstract]
 type rtop = {
   execute: (. bool, string) => Js.Promise.t(list(Worker_Types.blockData)),
-  /* reset: (. unit) => Js.Promise.t(unit),
-     reasonSyntax: (. unit) => Js.Promise.t(unit),
-     mlSyntax: (. unit) => Js.Promise.t(unit),
-     parseError: (. string, string) => Js.Promise.t(string), */
+  executeMany:
+    (. Belt.Map.String.t(string)) =>
+    Js.Promise.t(Belt.Map.String.t(list(Worker_Types.blockData))),
 };
 let worker = RtopWorker.make();
 
 let rtop: rtop = Comlink.comlink |. Comlink.proxy(worker);
 
 let execute = rtop |. executeGet;
+
+let executeMany = rtop |. executeManyGet;


### PR DESCRIPTION
Additionally I think clearing up widgets in lower blocks should be cleared when the current field is updated.