### PR TITLE
Allow anonymous editing

### DIFF
--- a/client/bsconfig.json
+++ b/client/bsconfig.json
@@ -35,6 +35,6 @@
   "bs-dev-dependencies": ["@glennsl/bs-jest"],
   "refmt": 3,
   "warnings": {
-    "error": "+5"
+    "error": "+5+8"
   }
 }

--- a/client/graphql_schema.json
+++ b/client/graphql_schema.json
@@ -1070,6 +1070,33 @@
                     "name": null,
                     "ofType": {
                       "kind": "INPUT_OBJECT",
+                      "name": "note_edit_token_bool_exp",
+                      "ofType": null
+                    }
+                  },
+                  "description": "filter the rows which have to be deleted"
+                }
+              ],
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "delete_note_edit_token",
+              "type": {
+                "kind": "OBJECT",
+                "name": "note_edit_token_mutation_response",
+                "ofType": null
+              },
+              "description": "delete data from the table: \"note_edit_token\""
+            },
+            {
+              "args": [
+                {
+                  "name": "where",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
                       "name": "note_revision_bool_exp",
                       "ofType": null
                     }
@@ -1239,6 +1266,51 @@
                 "ofType": null
               },
               "description": "insert data into the table: \"note\""
+            },
+            {
+              "args": [
+                {
+                  "name": "objects",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "LIST",
+                      "name": null,
+                      "ofType": {
+                        "kind": "NON_NULL",
+                        "name": null,
+                        "ofType": {
+                          "kind": "INPUT_OBJECT",
+                          "name": "note_edit_token_insert_input",
+                          "ofType": null
+                        }
+                      }
+                    }
+                  },
+                  "description": "the rows to be inserted"
+                },
+                {
+                  "name": "on_conflict",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "note_edit_token_on_conflict",
+                    "ofType": null
+                  },
+                  "description": "on conflict condition"
+                }
+              ],
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "insert_note_edit_token",
+              "type": {
+                "kind": "OBJECT",
+                "name": "note_edit_token_mutation_response",
+                "ofType": null
+              },
+              "description": "insert data into the table: \"note_edit_token\""
             },
             {
               "args": [
@@ -1541,6 +1613,43 @@
                 "ofType": null
               },
               "description": "update data of the table: \"note\""
+            },
+            {
+              "args": [
+                {
+                  "name": "_set",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "note_edit_token_set_input",
+                    "ofType": null
+                  },
+                  "description": "sets the columns of the filtered rows to the given values"
+                },
+                {
+                  "name": "where",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "note_edit_token_bool_exp",
+                      "ofType": null
+                    }
+                  },
+                  "description": "filter the rows which have to be updated"
+                }
+              ],
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "update_note_edit_token",
+              "type": {
+                "kind": "OBJECT",
+                "name": "note_edit_token_mutation_response",
+                "ofType": null
+              },
+              "description": "update data of the table: \"note_edit_token\""
             },
             {
               "args": [
@@ -1863,6 +1972,79 @@
               "description": null
             },
             {
+              "args": [
+                {
+                  "name": "limit",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "description": "limit the nuber of rows returned"
+                },
+                {
+                  "name": "offset",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "description": "skip the first n rows. Use only with order_by"
+                },
+                {
+                  "name": "order_by",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "note_edit_token_order_by",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "description": "sort the rows by one or more columns"
+                },
+                {
+                  "name": "where",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "note_edit_token_bool_exp",
+                    "ofType": null
+                  },
+                  "description": "filter the rows returned"
+                }
+              ],
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "edit_tokens",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "note_edit_token",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "description": "An array relationship"
+            },
+            {
               "args": [],
               "isDeprecated": false,
               "deprecationReason": null,
@@ -2091,6 +2273,16 @@
               "description": null
             },
             {
+              "name": "edit_tokens",
+              "defaultValue": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "note_edit_token_bool_exp",
+                "ofType": null
+              },
+              "description": null
+            },
+            {
               "name": "id",
               "defaultValue": null,
               "type": {
@@ -2251,6 +2443,369 @@
           "name": "note_delete_key_input",
           "enumValues": null,
           "description": "delete key/value pair or string element. key/value pairs are matched based on their key value",
+          "fields": null
+        },
+        {
+          "inputFields": null,
+          "kind": "OBJECT",
+          "possibleTypes": null,
+          "interfaces": [],
+          "name": "note_edit_token",
+          "enumValues": null,
+          "description": "columns and relationships of \"note_edit_token\"",
+          "fields": [
+            {
+              "args": [],
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "note_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "description": null
+            },
+            {
+              "args": [],
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "token",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "description": null
+            }
+          ]
+        },
+        {
+          "inputFields": [
+            {
+              "name": "_and",
+              "defaultValue": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "note_edit_token_bool_exp",
+                  "ofType": null
+                }
+              },
+              "description": null
+            },
+            {
+              "name": "_not",
+              "defaultValue": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "note_edit_token_bool_exp",
+                "ofType": null
+              },
+              "description": null
+            },
+            {
+              "name": "_or",
+              "defaultValue": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "INPUT_OBJECT",
+                  "name": "note_edit_token_bool_exp",
+                  "ofType": null
+                }
+              },
+              "description": null
+            },
+            {
+              "name": "note_id",
+              "defaultValue": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "varchar_comparison_exp",
+                "ofType": null
+              },
+              "description": null
+            },
+            {
+              "name": "token",
+              "defaultValue": null,
+              "type": {
+                "kind": "INPUT_OBJECT",
+                "name": "varchar_comparison_exp",
+                "ofType": null
+              },
+              "description": null
+            }
+          ],
+          "kind": "INPUT_OBJECT",
+          "possibleTypes": null,
+          "interfaces": null,
+          "name": "note_edit_token_bool_exp",
+          "enumValues": null,
+          "description": "Boolean expression to filter rows from the table \"note_edit_token\". All fields are combined with a logical 'AND'.",
+          "fields": null
+        },
+        {
+          "inputFields": null,
+          "kind": "ENUM",
+          "possibleTypes": null,
+          "interfaces": null,
+          "name": "note_edit_token_constraint",
+          "enumValues": [
+            {
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "note_edit_token_pkey",
+              "description": "unique or primary key constraint"
+            }
+          ],
+          "description": "unique or primary key constraints on table \"note_edit_token\"",
+          "fields": null
+        },
+        {
+          "inputFields": [
+            {
+              "name": "note_id",
+              "defaultValue": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "description": null
+            },
+            {
+              "name": "token",
+              "defaultValue": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "description": null
+            }
+          ],
+          "kind": "INPUT_OBJECT",
+          "possibleTypes": null,
+          "interfaces": null,
+          "name": "note_edit_token_insert_input",
+          "enumValues": null,
+          "description": "input type for inserting data into table \"note_edit_token\"",
+          "fields": null
+        },
+        {
+          "inputFields": null,
+          "kind": "OBJECT",
+          "possibleTypes": null,
+          "interfaces": [],
+          "name": "note_edit_token_mutation_response",
+          "enumValues": null,
+          "description": "response of any mutation on the table \"note_edit_token\"",
+          "fields": [
+            {
+              "args": [],
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "affected_rows",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "description": "number of affected rows by the mutation"
+            },
+            {
+              "args": [],
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "returning",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "note_edit_token_no_rels",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "description": "data of the affected rows by the mutation"
+            }
+          ]
+        },
+        {
+          "inputFields": null,
+          "kind": "OBJECT",
+          "possibleTypes": null,
+          "interfaces": [],
+          "name": "note_edit_token_no_rels",
+          "enumValues": null,
+          "description": "only postgres columns (no relationships) from \"note_edit_token\"",
+          "fields": [
+            {
+              "args": [],
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "note_id",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "description": null
+            },
+            {
+              "args": [],
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "token",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "description": null
+            }
+          ]
+        },
+        {
+          "inputFields": [
+            {
+              "name": "action",
+              "defaultValue": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "conflict_action",
+                  "ofType": null
+                }
+              },
+              "description": null
+            },
+            {
+              "name": "constraint",
+              "defaultValue": null,
+              "type": {
+                "kind": "ENUM",
+                "name": "note_edit_token_constraint",
+                "ofType": null
+              },
+              "description": null
+            }
+          ],
+          "kind": "INPUT_OBJECT",
+          "possibleTypes": null,
+          "interfaces": null,
+          "name": "note_edit_token_on_conflict",
+          "enumValues": null,
+          "description": "on conflict condition type for table \"note_edit_token\"",
+          "fields": null
+        },
+        {
+          "inputFields": null,
+          "kind": "ENUM",
+          "possibleTypes": null,
+          "interfaces": null,
+          "name": "note_edit_token_order_by",
+          "enumValues": [
+            {
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "note_id_asc",
+              "description": "in the ascending order of \"note_id\", nulls last"
+            },
+            {
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "note_id_asc_nulls_first",
+              "description": "in the ascending order of \"note_id\", nulls first"
+            },
+            {
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "note_id_desc",
+              "description": "in the descending order of \"note_id\", nulls last"
+            },
+            {
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "note_id_desc_nulls_first",
+              "description": "in the descending order of \"note_id\", nulls first"
+            },
+            {
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "token_asc",
+              "description": "in the ascending order of \"token\", nulls last"
+            },
+            {
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "token_asc_nulls_first",
+              "description": "in the ascending order of \"token\", nulls first"
+            },
+            {
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "token_desc",
+              "description": "in the descending order of \"token\", nulls last"
+            },
+            {
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "token_desc_nulls_first",
+              "description": "in the descending order of \"token\", nulls first"
+            }
+          ],
+          "description": "ordering options when selecting data from \"note_edit_token\"",
+          "fields": null
+        },
+        {
+          "inputFields": [
+            {
+              "name": "note_id",
+              "defaultValue": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "description": null
+            },
+            {
+              "name": "token",
+              "defaultValue": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "description": null
+            }
+          ],
+          "kind": "INPUT_OBJECT",
+          "possibleTypes": null,
+          "interfaces": null,
+          "name": "note_edit_token_set_input",
+          "enumValues": null,
+          "description": "input type for updating data in table \"note_edit_token\"",
           "fields": null
         },
         {
@@ -3505,6 +4060,79 @@
                       "name": null,
                       "ofType": {
                         "kind": "ENUM",
+                        "name": "note_edit_token_order_by",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "description": "sort the rows by one or more columns"
+                },
+                {
+                  "name": "where",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "note_edit_token_bool_exp",
+                    "ofType": null
+                  },
+                  "description": "filter the rows returned"
+                }
+              ],
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "note_edit_token",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "note_edit_token",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "description": "fetch data from the table: \"note_edit_token\""
+            },
+            {
+              "args": [
+                {
+                  "name": "limit",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "description": "limit the nuber of rows returned"
+                },
+                {
+                  "name": "offset",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "description": "skip the first n rows. Use only with order_by"
+                },
+                {
+                  "name": "order_by",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
                         "name": "note_revision_order_by",
                         "ofType": null
                       }
@@ -3920,6 +4548,79 @@
                 }
               },
               "description": "fetch data from the table: \"note\""
+            },
+            {
+              "args": [
+                {
+                  "name": "limit",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "description": "limit the nuber of rows returned"
+                },
+                {
+                  "name": "offset",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "description": "skip the first n rows. Use only with order_by"
+                },
+                {
+                  "name": "order_by",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "ENUM",
+                        "name": "note_edit_token_order_by",
+                        "ofType": null
+                      }
+                    }
+                  },
+                  "description": "sort the rows by one or more columns"
+                },
+                {
+                  "name": "where",
+                  "defaultValue": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "note_edit_token_bool_exp",
+                    "ofType": null
+                  },
+                  "description": "filter the rows returned"
+                }
+              ],
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "name": "note_edit_token",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "note_edit_token",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "description": "fetch data from the table: \"note_edit_token\""
             },
             {
               "args": [

--- a/client/src/App.re
+++ b/client/src/App.re
@@ -26,6 +26,7 @@ let make = _children => {
   },
   render: ({state}) =>
     <ReasonApollo.Provider client=GqlClient.instance>
+      <UI_Notification.Provider />
       <AuthStatus.Provider />
       (
         switch (state) {

--- a/client/src/Auth.re
+++ b/client/src/Auth.re
@@ -2,9 +2,9 @@ module type LocalStorageKey = {let key: string;};
 module LocalStorageOperaton = (K: LocalStorageKey) => {
   open Dom.Storage;
   let key = K.key;
-  let set = value => setItem(K.key, value, localStorage);
-  let get = () => getItem(K.key, localStorage);
-  let remove = () => removeItem(K.key, localStorage);
+  let set = value => setItem(key, value, localStorage);
+  let get = () => getItem(key, localStorage);
+  let remove = () => removeItem(key, localStorage);
 };
 
 module Auth = {
@@ -16,6 +16,11 @@ module Auth = {
   module UserId =
     LocalStorageOperaton({
       let key = "rtop:userId";
+    });
+
+  module EditToken =
+    LocalStorageOperaton({
+      let key = "rtop:editToken";
     });
 
   let githubLoginRedirect = Config.authDomain ++ "/auth/github";

--- a/client/src/Auth.re
+++ b/client/src/Auth.re
@@ -23,6 +23,15 @@ module Auth = {
       let key = "rtop:editToken";
     });
 
+  let getOrCreateEditToken = () =>
+    switch (EditToken.get()) {
+    | None =>
+      let newToken = Utils.generateId();
+      EditToken.set(newToken);
+      newToken;
+    | Some(editToken) => editToken
+    };
+
   let githubLoginRedirect = Config.authDomain ++ "/auth/github";
 
   let decodeUserId = json => Json.Decode.(json |> field("userId", string));

--- a/client/src/AuthStatus.re
+++ b/client/src/AuthStatus.re
@@ -25,6 +25,22 @@ module Provider = {
   let make = _children: ReasonReact.component(unit, 'a, unit) => {
     ...component,
     didMount: self => {
+      let _ =
+        Auth.(
+          /*
+           * This set edit token on initial load
+           * only if user is not login
+           * AND token is empty
+           */
+          switch (UserId.get()) {
+          | Some(_) => ()
+          | None =>
+            switch (EditToken.get()) {
+            | None => EditToken.set(Utils.generateId())
+            | Some(_) => ()
+            }
+          }
+        );
       open Webapi.Dom;
 
       let listener = event => {

--- a/client/src/AuthStatus.re
+++ b/client/src/AuthStatus.re
@@ -6,6 +6,11 @@ type state =
   | Anonymous
   | Login(string);
 
+let authStateToUserId =
+  fun
+  | Anonymous => Config.anonymousUserId
+  | Login(id) => id;
+
 let localStorageDataToState =
   fun
   | None => Anonymous

--- a/client/src/AuthStatus.re
+++ b/client/src/AuthStatus.re
@@ -1,6 +1,6 @@
 open Utils;
 module Auth = Auth.Auth;
-let getCurrentState = Auth.getUserId;
+let getCurrentState = Auth.UserId.get;
 
 type state = option(int);
 
@@ -30,7 +30,7 @@ module Provider = {
       let listener = event => {
         let event = Auth.toStorageEvent(event);
         let key = event->StorageEvent.key;
-        if (key == Auth.userIdKey) {
+        if (key == Auth.UserId.key) {
           let newValue = event->StorageEvent.newValue->Utils.toNullable;
           Store.broadcast(newValue->Js.Nullable.toOption);
         };

--- a/client/src/GqlClient.re
+++ b/client/src/GqlClient.re
@@ -11,7 +11,7 @@ let httpLink = ApolloLinks.createHttpLink(~uri=Config.graphqlEndpoint, ());
 
 let authLink =
   ApolloLinks.createContextLink(() => {
-    let token = Auth.Auth.getToken();
+    let token = Auth.Auth.Token.get();
     switch (token) {
     | None => Js.Obj.empty()
     | Some(token) => {

--- a/client/src/GqlClient.re
+++ b/client/src/GqlClient.re
@@ -12,14 +12,20 @@ let httpLink = ApolloLinks.createHttpLink(~uri=Config.graphqlEndpoint, ());
 let authLink =
   ApolloLinks.createContextLink(() => {
     let token = Auth.Auth.Token.get();
+    let headers = Js.Dict.empty();
+
     switch (token) {
-    | None => Js.Obj.empty()
-    | Some(token) => {
-        "headers": {
-          "authorization": "Bearer " ++ token,
-        },
+    | None =>
+      switch (Auth.Auth.EditToken.get()) {
+      | None => ()
+      | Some(editToken) =>
+        headers->(Js.Dict.set("X-Hasura-Edit-Token", editToken))
       }
+    | Some(token) =>
+      headers->(Js.Dict.set("authorization", "Bearer " ++ token))
     };
+
+    {"headers": headers};
   });
 
 let link = authLink->(concat(httpLink));

--- a/client/src/Home.re
+++ b/client/src/Home.re
@@ -13,9 +13,9 @@ let make = _children => {
       <hr />
       <AuthStatus.IsAuthenticated>
         ...(
-             state =>
-               switch (state) {
-               | None =>
+             user =>
+               switch (user) {
+               | Anonymous =>
                  <p>
                    {
                      let href = Route.routeToUrl(Route.AuthGithub);
@@ -31,7 +31,7 @@ let make = _children => {
                      </a>;
                    }
                  </p>
-               | Some(userId) =>
+               | Login(userId) =>
                  <div>
                    <UI_UserInfo userId />
                    <p> <Link route=Route.AuthLogout> "Logout"->str </Link> </p>

--- a/client/src/Note.re
+++ b/client/src/Note.re
@@ -62,7 +62,7 @@ module EnsureUrlEncodedData = {
       <NoteSave noteKind>
         ...(
              (~noteSaveStatus, ~userId, ~onSave) => {
-               let noteOwner =
+               let noteOwnerId =
                  switch (note##owner) {
                  | None => None
                  | Some(owner) =>
@@ -73,8 +73,8 @@ module EnsureUrlEncodedData = {
                  };
                <Editor_Note
                  title=note##title->optionToEmptyString
-                 userId
-                 ?noteOwner
+                 isEditable=false
+                 ?noteOwnerId
                  blocks=(
                    switch (note##data) {
                    | None => [||]

--- a/client/src/Note.re
+++ b/client/src/Note.re
@@ -3,11 +3,7 @@ module GetNote = [%graphql
     query getNote (
       $noteId: String!
     ) {
-      note (
-        where: {
-          id : {_eq: $noteId}
-        }
-      ) {
+      note (where: {id : {_eq: $noteId}}) {
         id
         title
         data
@@ -17,6 +13,9 @@ module GetNote = [%graphql
           username
           avatar
         }
+      }
+      note_edit_token(where: {note_id: {_eq: $noteId}}) {
+        note_id
       }
     }
   |}

--- a/client/src/Note.re
+++ b/client/src/Note.re
@@ -35,7 +35,7 @@ module EnsureUrlEncodedData = {
   let component = ReasonReact.reducerComponent("Note_EnsureUrlEncodedData");
 
   let make =
-      (~note, ~noteKind, ~noteId, _children)
+      (~note, ~noteEditToken, ~noteKind, ~noteId, _children)
       : React.component(unit, 'a, action) => {
     ...component,
     didMount: ({send}) =>
@@ -61,7 +61,7 @@ module EnsureUrlEncodedData = {
     render: _send =>
       <NoteSave noteKind>
         ...(
-             (~noteSaveStatus, ~userId, ~onSave) => {
+             (~noteSaveStatus, ~user, ~onSave) => {
                let noteOwnerId =
                  switch (note##owner) {
                  | None => None
@@ -71,9 +71,19 @@ module EnsureUrlEncodedData = {
                    | Some(id) => Some(id)
                    }
                  };
+
+               let isEditable =
+                 switch (user) {
+                 | Login(currentUserId) =>
+                   switch (noteOwnerId) {
+                   | None => false
+                   | Some(noteOwnerId) => noteOwnerId == currentUserId
+                   }
+                 | Anonymous => noteEditToken->Array.length > 0
+                 };
                <Editor_Note
                  title=note##title->optionToEmptyString
-                 isEditable=false
+                 isEditable
                  ?noteOwnerId
                  blocks=(
                    switch (note##data) {
@@ -112,6 +122,7 @@ let make = (~noteInfo: Route.noteRouteConfig, _children) => {
                      <EnsureUrlEncodedData
                        noteId=noteInfo.noteId
                        note
+                       noteEditToken=response##note_edit_token
                        noteKind=(Old(noteInfo.noteId))
                      />
                    )

--- a/client/src/Note.re
+++ b/client/src/Note.re
@@ -90,8 +90,8 @@ let make = (~noteInfo: Route.noteRouteConfig, _children) => {
            isLogin => {
              let userId =
                switch (isLogin) {
-               | None => Config.anonymousUserId
-               | Some(userId) => userId
+               | Anonymous => Config.anonymousUserId
+               | Login(userId) => userId
                };
              <GetNoteComponent variables=noteQuery##variables>
                ...(

--- a/client/src/NoteSave.re
+++ b/client/src/NoteSave.re
@@ -26,7 +26,17 @@ type action =
    check with the original data to see if they are matched */
 let component = ReasonReact.reducerComponent("NoteSave");
 
-let make = (~noteKind: noteKind, children) => {
+let make =
+    (
+      ~noteKind: noteKind,
+      children:
+        (
+          ~noteSaveStatus: NoteSave_Types.noteSaveStatus,
+          ~user: AuthStatus.state,
+          ~onSave: 'a
+        ) =>
+        ReasonReact.reactElement,
+    ) => {
   ...component,
   initialState: () => {kind: noteKind},
   reducer: (action, _state) =>

--- a/client/src/NoteSave.re
+++ b/client/src/NoteSave.re
@@ -1,48 +1,3 @@
-open Utils_GraphqlPpx;
-
-module AddNoteGql = [%graphql
-  {|
-    mutation ($title: String!, $data: jsonb!, $id: String!, $userId: String!) {
-      addNote: insert_note(objects: {
-        title: $title,
-        id: $id,
-        user_id: $userId,
-        data: $data
-      }) {
-        returning {
-          id
-          updated_at
-          title
-          data
-        }
-      }
-    }
-  |}
-];
-
-module AddNoteComponent = ReasonApollo.CreateMutation(AddNoteGql);
-
-module UpdateNoteGql = [%graphql
-  {|
-    mutation ($noteId: String!, $data: jsonb!, $title: String!) {
-      update_note(
-        where: {
-          id: {_eq: $noteId}
-        }
-        _set: {
-        title: $title,
-        data: $data
-      }) {
-        returning {
-          updated_at
-        }
-      }
-    }
-  |}
-];
-
-module UpdateNoteComponent = ReasonApollo.CreateMutation(UpdateNoteGql);
-
 let replaceNoteRoute = (~noteId, ~json, ~title) =>
   Js.Promise.(
     LzString.async()
@@ -60,117 +15,65 @@ let replaceNoteRoute = (~noteId, ~json, ~title) =>
        )
     |> Utils.handleError
   );
-module NoteSave = {
-  open NoteSave_Types;
-  type action =
-    | SavedNewNote(id, string, Js.Json.t)
-    | SavedOldNote(id, string, Js.Json.t);
 
-  /* TODO:
-     When receive the mutation result,
-     check with the original data to see if they are matched */
-  let component = ReasonReact.reducerComponent("NoteSave");
+open NoteSave_Types;
+type action =
+  | SavedNewNote(id, string, Js.Json.t)
+  | SavedOldNote(id, string, Js.Json.t);
 
-  let make = (~noteKind: noteKind, children) => {
-    ...component,
-    initialState: () => {kind: noteKind},
-    reducer: (action, _state) =>
-      switch (action) {
-      | SavedNewNote(noteId, title, json) =>
-        ReasonReact.UpdateWithSideEffects(
-          {kind: Old(noteId)},
-          (_self => replaceNoteRoute(~noteId, ~json, ~title)->ignore),
-        )
-      | SavedOldNote(noteId, title, json) =>
-        ReasonReact.SideEffects(
-          (_self => replaceNoteRoute(~noteId, ~json, ~title)->ignore),
-        )
-      },
-    render: ({state, send}) =>
-      <AuthStatus.IsAuthenticated>
-        ...(
-             user =>
-               switch (user) {
-               | Anonymous => ReasonReact.null
-               | Login(userId) =>
-                 switch (state.kind) {
-                 | New =>
-                   <AddNoteComponent>
-                     ...(
-                          (mutation, createNoteResult) => {
-                            let {AddNoteComponent.loading} = createNoteResult;
-                            children(
-                              ~loading,
-                              ~onSave=(~title, ~data, ~userId) => {
-                                let noteId = Utils.generateId();
-                                let newNote =
-                                  AddNoteGql.make(
-                                    ~title,
-                                    ~data=data->Editor_Types.JsonEncode.encode,
-                                    ~id=noteId,
-                                    ~userId,
-                                    (),
-                                  );
-                                Js.Promise.(
-                                  mutation(~variables=newNote##variables, ())
-                                  |> then_(_result =>
-                                       send(
-                                         SavedNewNote(
-                                           noteId,
-                                           title,
-                                           data
-                                           ->Editor_Types.JsonEncode.encode,
-                                         ),
-                                       )
-                                       ->resolve
-                                     )
-                                )
-                                |> ignore;
-                              },
-                            );
-                          }
-                        )
-                   </AddNoteComponent>
-                 | Old(noteId) =>
-                   <UpdateNoteComponent>
-                     ...(
-                          (mutation, updateNoteResult) => {
-                            let {UpdateNoteComponent.loading} = updateNoteResult;
-                            children(
-                              ~loading,
-                              ~onSave=(~title, ~data, ~userId as _) => {
-                                let data =
-                                  data->Editor_Types.JsonEncode.encode;
-                                let updatedNote =
-                                  UpdateNoteGql.make(
-                                    ~title,
-                                    ~data,
-                                    ~noteId,
-                                    (),
-                                  );
-                                Js.Promise.(
-                                  mutation(
-                                    ~variables=updatedNote##variables,
-                                    ~refetchQueries=[|"getNote"|],
-                                    (),
-                                  )
-                                  |> then_(_data =>
-                                       SavedOldNote(noteId, title, data)
-                                       ->send
-                                       ->resolve
-                                     )
-                                )
-                                |> ignore;
-                              },
-                            );
-                          }
-                        )
-                   </UpdateNoteComponent>
-                 }
-               }
-           )
-      </AuthStatus.IsAuthenticated>,
-  };
+/* TODO:
+   When receive the mutation result,
+   check with the original data to see if they are matched */
+let component = ReasonReact.reducerComponent("NoteSave");
+
+let make = (~noteKind: noteKind, children) => {
+  ...component,
+  initialState: () => {kind: noteKind},
+  reducer: (action, _state) =>
+    switch (action) {
+    | SavedNewNote(noteId, title, json) =>
+      ReasonReact.UpdateWithSideEffects(
+        {kind: Old(noteId)},
+        (_self => replaceNoteRoute(~noteId, ~json, ~title)->ignore),
+      )
+    | SavedOldNote(noteId, title, json) =>
+      ReasonReact.SideEffects(
+        (_self => replaceNoteRoute(~noteId, ~json, ~title)->ignore),
+      )
+    },
+  render: ({state, send}) =>
+    <AuthStatus.IsAuthenticated>
+      ...(
+           user =>
+             switch (user) {
+             | Anonymous =>
+               <NoteSave_Anonymous
+                 kind=state.kind
+                 onSaveNewNote=(
+                   (noteId, title, data) =>
+                     SavedNewNote(noteId, title, data)->send
+                 )
+                 onSaveOldNote=(
+                   (noteId, title, data) =>
+                     SavedOldNote(noteId, title, data)->send
+                 )>
+                 ...children
+               </NoteSave_Anonymous>
+             | Login(userId) =>
+               <NoteSave_Login
+                 kind=state.kind
+                 userId
+                 onSaveNewNote=(
+                   (noteId, title, data) =>
+                     SavedNewNote(noteId, title, data)->send
+                 )
+                 onSaveOldNote=(
+                   (noteId, title, data) =>
+                     SavedOldNote(noteId, title, data)->send
+                 )>
+                 ...children
+               </NoteSave_Login>
+             }
+         )
+    </AuthStatus.IsAuthenticated>,
 };
-
-include NoteSave;

--- a/client/src/NoteSave_Anonymous.re
+++ b/client/src/NoteSave_Anonymous.re
@@ -1,0 +1,123 @@
+open Utils_GraphqlPpx;
+open GqlUpdateNote;
+
+module AddNoteAnonymousGql = [%graphql
+  {|
+    mutation (
+      $noteId: String!,
+      $editToken: String!,
+      $userId: String!,
+      $title: String!,
+      $data: jsonb!
+    ) {
+
+      insert_note_edit_token(objects:{
+        note_id: $noteId
+        token: $editToken
+      }) {
+        affected_rows
+      }
+
+      insert_note(objects: {
+        title: $title,
+        id: $noteId,
+        user_id: $userId,
+        data: $data
+      }) {
+        returning {
+          updated_at
+        }
+      }
+    }
+  |}
+];
+
+module AddNoteAnonymousComponent =
+  ReasonApollo.CreateMutation(AddNoteAnonymousGql);
+
+open NoteSave_Types;
+
+let component = ReasonReact.statelessComponent("NoteSave_Anonymous");
+
+let make = (~kind, ~user, ~onSaveNewNote, ~onSaveOldNote, children) => {
+  ...component,
+  render: _self =>
+    switch (kind) {
+    | New =>
+      <AddNoteAnonymousComponent>
+        ...(
+             (mutation, createNoteResult) => {
+               let {AddNoteAnonymousComponent.loading} = createNoteResult;
+               children(
+                 ~loading,
+                 ~user,
+                 ~onSave=(~title, ~data) => {
+                   let noteId = Utils.generateId();
+                   let newNote =
+                     AddNoteAnonymousGql.make(
+                       ~title,
+                       ~data=data->Editor_Types.JsonEncode.encode,
+                       ~noteId,
+                       ~userId=Config.anonymousUserId,
+                       ~editToken=Auth.Auth.getOrCreateEditToken(),
+                       (),
+                     );
+                   Js.Promise.(
+                     mutation(~variables=newNote##variables, ())
+                     |> then_(_result =>
+                          onSaveNewNote(
+                            noteId,
+                            title,
+                            data->Editor_Types.JsonEncode.encode,
+                          )
+                          ->resolve
+                        )
+                   )
+                   |> ignore;
+                 },
+               );
+             }
+           )
+      </AddNoteAnonymousComponent>
+    | Old(noteId) =>
+      <UpdateNoteComponent>
+        ...(
+             (mutation, updateNoteResult) => {
+               let {UpdateNoteComponent.loading} = updateNoteResult;
+               children(
+                 ~loading,
+                 ~user,
+                 ~onSave=(~title, ~data) => {
+                   let data = data->Editor_Types.JsonEncode.encode;
+                   let updatedNote =
+                     UpdateNoteGql.make(~title, ~data, ~noteId, ());
+                   Js.Promise.(
+                     mutation(
+                       ~variables=updatedNote##variables,
+                       ~refetchQueries=[|
+                         {
+                           "query": "getNote",
+                           "variables": {
+                             "where": {
+                               "id": {
+                                 "_eq": noteId,
+                               },
+                             },
+                           },
+                         }
+                         ->Utils_GraphqlPpx.hackRefetchQueries,
+                       |],
+                       (),
+                     )
+                     |> then_(_data =>
+                          onSaveOldNote(noteId, title, data)->resolve
+                        )
+                   )
+                   |> ignore;
+                 },
+               );
+             }
+           )
+      </UpdateNoteComponent>
+    },
+};

--- a/client/src/NoteSave_Anonymous.re
+++ b/client/src/NoteSave_Anonymous.re
@@ -64,7 +64,7 @@ let make = (~kind, ~onSaveNewNote, ~onSaveOldNote, children) => {
 
                    | NotCalled => NoteSave_Done
                    },
-                 ~userId,
+                 ~user=AuthStatus.Anonymous,
                  ~onSave=(~title, ~data) => {
                    let data = data->Editor_Types.JsonEncode.encode;
                    let noteId = Utils.generateId();
@@ -112,7 +112,7 @@ let make = (~kind, ~onSaveNewNote, ~onSaveOldNote, children) => {
 
                    | NotCalled => NoteSave_Done
                    },
-                 ~userId,
+                 ~user=AuthStatus.Anonymous,
                  ~onSave=(~title, ~data) => {
                    let data = data->Editor_Types.JsonEncode.encode;
                    let updatedNote =

--- a/client/src/NoteSave_Login.re
+++ b/client/src/NoteSave_Login.re
@@ -54,7 +54,7 @@ let make = (~kind, ~userId, ~onSaveNewNote, ~onSaveOldNote, children) => {
 
                    | NotCalled => NoteSave_Done
                    },
-                 ~userId,
+                 ~user=AuthStatus.Login(userId),
                  ~onSave=(~title, ~data) => {
                    let data = data->Editor_Types.JsonEncode.encode;
                    let noteId = Utils.generateId();
@@ -101,7 +101,7 @@ let make = (~kind, ~userId, ~onSaveNewNote, ~onSaveOldNote, children) => {
 
                    | NotCalled => NoteSave_Done
                    },
-                 ~userId,
+                 ~user=AuthStatus.Login(userId),
                  ~onSave=(~title, ~data) => {
                    let data = data->Editor_Types.JsonEncode.encode;
                    let updatedNote =

--- a/client/src/NoteSave_Login.re
+++ b/client/src/NoteSave_Login.re
@@ -9,15 +9,13 @@ module AddNoteLoginGql = [%graphql
       $title: String!,
       $data: jsonb!
     ) {
-      insert_note(objects: {
+      mutate: insert_note(objects: {
         title: $title,
         id: $noteId,
         user_id: $userId,
         data: $data
       }) {
-        returning {
-          updated_at
-        }
+        affected_rows
       }
     }
   |}
@@ -29,7 +27,7 @@ open NoteSave_Types;
 
 let component = ReasonReact.statelessComponent("NoteSave_Anonymous");
 
-let make = (~kind, ~user, ~onSaveNewNote, ~onSaveOldNote, children) => {
+let make = (~kind, ~userId, ~onSaveNewNote, ~onSaveOldNote, children) => {
   ...component,
   render: _self =>
     switch (kind) {
@@ -37,33 +35,41 @@ let make = (~kind, ~user, ~onSaveNewNote, ~onSaveOldNote, children) => {
       <AddNoteLoginComponent>
         ...(
              (mutation, createNoteResult) => {
-               let {AddNoteLoginComponent.loading} = createNoteResult;
+               let {AddNoteLoginComponent.result} = createNoteResult;
                children(
-                 ~loading,
-                 ~user,
+                 ~noteSaveStatus=
+                   switch (result) {
+                   | Loading => NoteSave_Loading
+                   | Error(_apolloError) => NoteSave_Error
+                   | Data(data) =>
+                     switch (data##mutate) {
+                     | None => NoteSave_Error
+                     | Some(mutate) =>
+                       if (mutate##affected_rows > 0) {
+                         NoteSave_Done;
+                       } else {
+                         NoteSave_Error;
+                       }
+                     }
+
+                   | NotCalled => NoteSave_Done
+                   },
+                 ~userId,
                  ~onSave=(~title, ~data) => {
+                   let data = data->Editor_Types.JsonEncode.encode;
                    let noteId = Utils.generateId();
                    let newNote =
                      AddNoteLoginGql.make(
                        ~title,
-                       ~data=data->Editor_Types.JsonEncode.encode,
+                       ~data,
                        ~noteId,
-                       ~userId=
-                         switch (user) {
-                         | AuthStatus.Anonymous => Config.anonymousUserId
-                         | Login(id) => id
-                         },
+                       ~userId,
                        (),
                      );
                    Js.Promise.(
                      mutation(~variables=newNote##variables, ())
                      |> then_(_result =>
-                          onSaveNewNote(
-                            noteId,
-                            title,
-                            data->Editor_Types.JsonEncode.encode,
-                          )
-                          ->resolve
+                          onSaveNewNote(noteId, title, data)->resolve
                         )
                    )
                    |> ignore;
@@ -76,10 +82,26 @@ let make = (~kind, ~user, ~onSaveNewNote, ~onSaveOldNote, children) => {
       <UpdateNoteComponent>
         ...(
              (mutation, updateNoteResult) => {
-               let {UpdateNoteComponent.loading} = updateNoteResult;
+               let {UpdateNoteComponent.result} = updateNoteResult;
                children(
-                 ~loading,
-                 ~user,
+                 ~noteSaveStatus=
+                   switch (result) {
+                   | Loading => NoteSave_Loading
+                   | Error(_apolloError) => NoteSave_Error
+                   | Data(data) =>
+                     switch (data##mutate) {
+                     | None => NoteSave_Error
+                     | Some(mutate) =>
+                       if (mutate##affected_rows > 0) {
+                         NoteSave_Done;
+                       } else {
+                         NoteSave_Error;
+                       }
+                     }
+
+                   | NotCalled => NoteSave_Done
+                   },
+                 ~userId,
                  ~onSave=(~title, ~data) => {
                    let data = data->Editor_Types.JsonEncode.encode;
                    let updatedNote =
@@ -87,19 +109,7 @@ let make = (~kind, ~user, ~onSaveNewNote, ~onSaveOldNote, children) => {
                    Js.Promise.(
                      mutation(
                        ~variables=updatedNote##variables,
-                       ~refetchQueries=[|
-                         {
-                           "query": "getNote",
-                           "variables": {
-                             "where": {
-                               "id": {
-                                 "_eq": noteId,
-                               },
-                             },
-                           },
-                         }
-                         ->Utils_GraphqlPpx.hackRefetchQueries,
-                       |],
+                       ~refetchQueries=[|"getNote"|],
                        (),
                      )
                      |> then_(_data =>

--- a/client/src/NoteSave_Login.re
+++ b/client/src/NoteSave_Login.re
@@ -1,0 +1,116 @@
+open Utils_GraphqlPpx;
+open GqlUpdateNote;
+
+module AddNoteLoginGql = [%graphql
+  {|
+    mutation (
+      $noteId: String!,
+      $userId: String!,
+      $title: String!,
+      $data: jsonb!
+    ) {
+      insert_note(objects: {
+        title: $title,
+        id: $noteId,
+        user_id: $userId,
+        data: $data
+      }) {
+        returning {
+          updated_at
+        }
+      }
+    }
+  |}
+];
+
+module AddNoteLoginComponent = ReasonApollo.CreateMutation(AddNoteLoginGql);
+
+open NoteSave_Types;
+
+let component = ReasonReact.statelessComponent("NoteSave_Anonymous");
+
+let make = (~kind, ~user, ~onSaveNewNote, ~onSaveOldNote, children) => {
+  ...component,
+  render: _self =>
+    switch (kind) {
+    | New =>
+      <AddNoteLoginComponent>
+        ...(
+             (mutation, createNoteResult) => {
+               let {AddNoteLoginComponent.loading} = createNoteResult;
+               children(
+                 ~loading,
+                 ~user,
+                 ~onSave=(~title, ~data) => {
+                   let noteId = Utils.generateId();
+                   let newNote =
+                     AddNoteLoginGql.make(
+                       ~title,
+                       ~data=data->Editor_Types.JsonEncode.encode,
+                       ~noteId,
+                       ~userId=
+                         switch (user) {
+                         | AuthStatus.Anonymous => Config.anonymousUserId
+                         | Login(id) => id
+                         },
+                       (),
+                     );
+                   Js.Promise.(
+                     mutation(~variables=newNote##variables, ())
+                     |> then_(_result =>
+                          onSaveNewNote(
+                            noteId,
+                            title,
+                            data->Editor_Types.JsonEncode.encode,
+                          )
+                          ->resolve
+                        )
+                   )
+                   |> ignore;
+                 },
+               );
+             }
+           )
+      </AddNoteLoginComponent>
+    | Old(noteId) =>
+      <UpdateNoteComponent>
+        ...(
+             (mutation, updateNoteResult) => {
+               let {UpdateNoteComponent.loading} = updateNoteResult;
+               children(
+                 ~loading,
+                 ~user,
+                 ~onSave=(~title, ~data) => {
+                   let data = data->Editor_Types.JsonEncode.encode;
+                   let updatedNote =
+                     UpdateNoteGql.make(~title, ~data, ~noteId, ());
+                   Js.Promise.(
+                     mutation(
+                       ~variables=updatedNote##variables,
+                       ~refetchQueries=[|
+                         {
+                           "query": "getNote",
+                           "variables": {
+                             "where": {
+                               "id": {
+                                 "_eq": noteId,
+                               },
+                             },
+                           },
+                         }
+                         ->Utils_GraphqlPpx.hackRefetchQueries,
+                       |],
+                       (),
+                     )
+                     |> then_(_data =>
+                          onSaveOldNote(noteId, title, data)->resolve
+                        )
+                   )
+                   |> ignore;
+                 },
+               );
+             }
+           )
+      </UpdateNoteComponent>
+    },
+};

--- a/client/src/NoteSave_Types.re
+++ b/client/src/NoteSave_Types.re
@@ -4,3 +4,8 @@ type noteKind =
   | Old(id);
 
 type state = {kind: noteKind};
+
+type noteSaveStatus =
+  | NoteSave_Done
+  | NoteSave_Loading
+  | NoteSave_Error;

--- a/client/src/NoteSave_Types.re
+++ b/client/src/NoteSave_Types.re
@@ -9,3 +9,15 @@ type noteSaveStatus =
   | NoteSave_Done
   | NoteSave_Loading
   | NoteSave_Error;
+
+let noteSaveStatusToString =
+  if (Utils.env == "production") {
+    _noteSaveStatus => "";
+  } else {
+    noteSaveStatus =>
+      switch (noteSaveStatus) {
+      | NoteSave_Done => "NoteSave_Done"
+      | NoteSave_Loading => "NoteSave_Loading"
+      | NoteSave_Error => "NoteSave_Error"
+      };
+  };

--- a/client/src/NoteSave_Types.re
+++ b/client/src/NoteSave_Types.re
@@ -1,0 +1,6 @@
+type id = string;
+type noteKind =
+  | New
+  | Old(id);
+
+type state = {kind: noteKind};

--- a/client/src/Note_New.re
+++ b/client/src/Note_New.re
@@ -13,7 +13,7 @@ let make = _children => {
     <NoteSave noteKind=New>
       ...(
            (~noteSaveStatus, ~userId, ~onSave) =>
-             <Editor_Note blocks noteSaveStatus onSave userId />
+             <Editor_Note blocks noteSaveStatus onSave isEditable=true />
          )
     </NoteSave>,
 };

--- a/client/src/Note_New.re
+++ b/client/src/Note_New.re
@@ -12,7 +12,7 @@ let make = _children => {
   render: _self =>
     <NoteSave noteKind=New>
       ...(
-           (~noteSaveStatus, ~userId, ~onSave) =>
+           (~noteSaveStatus, ~user as _, ~onSave) =>
              <Editor_Note blocks noteSaveStatus onSave isEditable=true />
          )
     </NoteSave>,

--- a/client/src/Note_New.re
+++ b/client/src/Note_New.re
@@ -10,21 +10,10 @@ let component = ReasonReact.statelessComponent("Note_New");
 let make = _children => {
   ...component,
   render: _self =>
-    <AuthStatus.IsAuthenticated>
+    <NoteSave noteKind=New>
       ...(
-           isLogin => {
-             let userId =
-               switch (isLogin) {
-               | Anonymous => Config.anonymousUserId
-               | Login(userId) => userId
-               };
-             <NoteSave noteKind=New>
-               ...(
-                    (~loading, ~onSave) =>
-                      <Editor_Note blocks loading onSave=(onSave(~userId)) />
-                  )
-             </NoteSave>;
-           }
+           (~noteSaveStatus, ~userId, ~onSave) =>
+             <Editor_Note blocks noteSaveStatus onSave userId />
          )
-    </AuthStatus.IsAuthenticated>,
+    </NoteSave>,
 };

--- a/client/src/Note_New.re
+++ b/client/src/Note_New.re
@@ -15,8 +15,8 @@ let make = _children => {
            isLogin => {
              let userId =
                switch (isLogin) {
-               | None => Config.anonymousUserId
-               | Some(userId) => userId
+               | Anonymous => Config.anonymousUserId
+               | Login(userId) => userId
                };
              <NoteSave noteKind=New>
                ...(

--- a/client/src/Popup.re
+++ b/client/src/Popup.re
@@ -16,6 +16,6 @@ let openPopup = (~width=1024, ~height=640, url) => {
   let params = {j|width=$(width), height=$(height), top=$(top), left=$(left)|j};
   let window = Webapi.Dom.window;
   window
-  ->(Webapi.Dom.Window.open_(~url, ~name="authWindow", ~features=params));
-  ();
+  ->(Webapi.Dom.Window.open_(~url, ~name="authWindow", ~features=params))
+  ->ignore;
 };

--- a/client/src/Utils_GraphqlPpx.re
+++ b/client/src/Utils_GraphqlPpx.re
@@ -3,3 +3,12 @@ let decodeBlockData =
   fun
   | None => None
   | Some(json) => Some(Editor_Types.JsonDecode.decode(json));
+
+external hackRefetchQueries:
+  {
+    .
+    "query": string,
+    "variables": Js.t('a),
+  } =>
+  string =
+  "%identity";

--- a/client/src/components/UI_Notification.css
+++ b/client/src/components/UI_Notification.css
@@ -1,0 +1,27 @@
+.UI_Notification {
+  position: absolute;
+  z-index: 9;
+  top: -100px;
+  left: 0;
+  right: 0;
+  background: #eb5656;
+  color: #fff;
+  text-align: center;
+  line-height: 2.5;
+  overflow: hidden;
+  border-radius: 0 0 4px 4px;
+  box-shadow: 0px 12px 20px -10px rgba(0, 0, 0, 0.28),
+    0px 4px 20px 0px rgba(0, 0, 0, 0.12), 0px 7px 8px -5px rgba(0, 0, 0, 0.2);
+  transition: top 225ms cubic-bezier(0, 0, 0.2, 1) 0ms;
+}
+
+@media (--md) {
+  .UI_Notification {
+    width: 40%;
+    margin: auto;
+  }
+}
+
+.UI_Notification--open {
+  top: var(--topbar-height);
+}

--- a/client/src/components/UI_Notification.re
+++ b/client/src/components/UI_Notification.re
@@ -1,0 +1,93 @@
+open Utils;
+
+Modules.require("./UI_Notification.css");
+type notice =
+  | Open(string)
+  | Close;
+/*
+ * TODO: Rewrite me to handle multiple notifications
+ * This is a really bad implementation of notification system
+ * It can only handle 1 notification at a time
+ * But since we don't have that much notification, it doesn't really matter
+ */
+
+module Store = {
+  let callback = ref(None);
+
+  let registerCallback = func => callback := Some(func);
+
+  let notify = message =>
+    switch (callback^) {
+    | None => ()
+    | Some(func) => func(message)
+    };
+};
+
+let notify: string => unit = Store.notify;
+
+module Provider = {
+  type state = {
+    notice,
+    timeoutId: ref(option(Js.Global.timeoutId)),
+  };
+
+  type action =
+    | OpenNotice(notice)
+    | CloseNotice;
+
+  let component = ReasonReact.reducerComponent("UI_Notification");
+
+  let openClassName = "UI_Notification--open";
+
+  let make = _children => {
+    ...component,
+    initialState: () => {notice: Close, timeoutId: ref(None)},
+    reducer: (action, state) =>
+      switch (action) {
+      | OpenNotice(notice) =>
+        ReasonReact.UpdateWithSideEffects(
+          {...state, notice},
+          (
+            ({send, state}) => {
+              switch (state.timeoutId^) {
+              | None => ()
+              | Some(id) => Js.Global.clearTimeout(id)
+              };
+              state.timeoutId :=
+                Js.Global.setTimeout(() => send(CloseNotice), 4000)->Some;
+            }
+          ),
+        )
+      | CloseNotice => ReasonReact.Update({...state, notice: Close})
+      },
+    didMount: ({state, send, onUnmount}) => {
+      Store.registerCallback(message => send(OpenNotice(Open(message))));
+      onUnmount(() =>
+        switch (state.timeoutId^) {
+        | None => ()
+        | Some(id) => Js.Global.clearTimeout(id)
+        }
+      );
+    },
+    render: ({state}) =>
+      <>
+        <div
+          className=(
+            "UI_Notification"
+            ++ (
+              switch (state.notice) {
+              | Open(message) => " UI_Notification--open"
+              | Close => ""
+              }
+            )
+          )>
+          (
+            switch (state.notice) {
+            | Open(message) => message->str
+            | Close => React.null
+            }
+          )
+        </div>
+      </>,
+  };
+};

--- a/client/src/gql/GqlUpdateNote.re
+++ b/client/src/gql/GqlUpdateNote.re
@@ -3,7 +3,7 @@ open Utils_GraphqlPpx;
 module UpdateNoteGql = [%graphql
   {|
     mutation ($noteId: String!, $data: jsonb!, $title: String!) {
-      update_note(
+      mutate: update_note(
         where: {
           id: {_eq: $noteId}
         }
@@ -11,9 +11,7 @@ module UpdateNoteGql = [%graphql
         title: $title,
         data: $data
       }) {
-        returning {
-          updated_at
-        }
+        affected_rows
       }
     }
   |}

--- a/client/src/gql/GqlUpdateNote.re
+++ b/client/src/gql/GqlUpdateNote.re
@@ -1,0 +1,22 @@
+open Utils_GraphqlPpx;
+
+module UpdateNoteGql = [%graphql
+  {|
+    mutation ($noteId: String!, $data: jsonb!, $title: String!) {
+      update_note(
+        where: {
+          id: {_eq: $noteId}
+        }
+        _set: {
+        title: $title,
+        data: $data
+      }) {
+        returning {
+          updated_at
+        }
+      }
+    }
+  |}
+];
+
+module UpdateNoteComponent = ReasonApollo.CreateMutation(UpdateNoteGql);

--- a/client/src_editor/Editor_Blocks.css
+++ b/client/src_editor/Editor_Blocks.css
@@ -1,18 +1,15 @@
-.cell__container {
-  margin-top: 25px;
+.block__container {
+  margin-top: var(--space4);
   padding: 0px;
   position: relative;
 }
 
-.cell__controls {
-  margin-top: 4px;
-  margin-left: 36px;
+.block__controls {
+  margin-top: var(--space2);
   display: flex;
   flex-direction: row-reverse;
 }
 
-.cell__controls-buttons {
-  flex: 0 0 50%;
+.block__controls--buttons {
   display: flex;
-  flex-direction: row-reverse;
 }

--- a/client/src_editor/Editor_Blocks.re
+++ b/client/src_editor/Editor_Blocks.re
@@ -38,7 +38,13 @@ let blockControlsButtons = (b_id, send) =>
 let component = ReasonReact.reducerComponent("Editor_Page");
 
 let make =
-    (~blocks: array(block), ~onUpdate, ~registerExecuteCallback=?, _children) => {
+    (
+      ~blocks: array(block),
+      ~readOnly=?,
+      ~onUpdate,
+      ~registerExecuteCallback=?,
+      _children,
+    ) => {
   ...component,
   initialState: () => {
     blocks: blocks->Editor_Blocks_Utils.syncLineNumber,
@@ -357,6 +363,7 @@ let make =
                       onBlockUp=(() => send(Block_FocusUp(b_id)))
                       onBlockDown=(() => send(Block_FocusDown(b_id)))
                       widgets=bc_widgets
+                      ?readOnly
                       firstLineNumber=bc_firstLineNumber
                     />
                   </div>
@@ -379,6 +386,7 @@ let make =
                         (newValue, diff) =>
                           send(Block_UpdateValue(b_id, newValue, diff))
                       )
+                      ?readOnly
                     />
                   </div>
                 }

--- a/client/src_editor/Editor_Blocks.re
+++ b/client/src_editor/Editor_Blocks.re
@@ -23,15 +23,15 @@ type state = {
 };
 
 let blockControlsButtons = (b_id, send) =>
-  <div className="cell__controls-buttons">
-    <button onClick=(_ => send(Block_Delete(b_id)))>
-      "Delete block"->str
+  <div className="block__controls--buttons">
+    <button onClick=(_ => send(Block_Add(b_id, BTyp_Code)))>
+      "Add code block"->str
     </button>
     <button onClick=(_ => send(Block_Add(b_id, BTyp_Text)))>
       "Add text block"->str
     </button>
-    <button onClick=(_ => send(Block_Add(b_id, BTyp_Code)))>
-      "Add code block"->str
+    <button onClick=(_ => send(Block_Delete(b_id)))>
+      "Delete block"->str
     </button>
   </div>;
 
@@ -40,7 +40,7 @@ let component = ReasonReact.reducerComponent("Editor_Page");
 let make =
     (
       ~blocks: array(block),
-      ~readOnly=?,
+      ~readOnly=false,
       ~onUpdate,
       ~registerExecuteCallback=?,
       _children,
@@ -339,7 +339,7 @@ let make =
       state.blocks
       ->(
           Belt.Array.mapU((. {b_id, b_data}) =>
-            <div key=b_id id=b_id className="cell__container">
+            <div key=b_id id=b_id className="block__container">
               (
                 switch (b_data) {
                 | B_Code({bc_value, bc_widgets, bc_firstLineNumber}) =>
@@ -363,7 +363,7 @@ let make =
                       onBlockUp=(() => send(Block_FocusUp(b_id)))
                       onBlockDown=(() => send(Block_FocusDown(b_id)))
                       widgets=bc_widgets
-                      ?readOnly
+                      readOnly
                       firstLineNumber=bc_firstLineNumber
                     />
                   </div>
@@ -386,14 +386,18 @@ let make =
                         (newValue, diff) =>
                           send(Block_UpdateValue(b_id, newValue, diff))
                       )
-                      ?readOnly
+                      readOnly
                     />
                   </div>
                 }
               )
-              <div className="cell__controls">
-                (blockControlsButtons(b_id, send))
-              </div>
+              (
+                readOnly ?
+                  React.null :
+                  <div className="block__controls">
+                    (blockControlsButtons(b_id, send))
+                  </div>
+              )
             </div>
           )
         )

--- a/client/src_editor/Editor_CodeBlock.re
+++ b/client/src_editor/Editor_CodeBlock.re
@@ -25,6 +25,7 @@ let make =
       ~onBlockUp=?,
       ~onBlockDown=?,
       ~onExecute,
+      ~readOnly=?,
       _children,
     )
     : ReasonReact.component(state, _, unit) => {
@@ -170,6 +171,7 @@ let make =
           ~matchBrackets=true,
           ~lineWrapping=true,
           ~firstLineNumber,
+          ~readOnly?,
           ~extraKeys={
             let key = Js.Dict.empty();
             key

--- a/client/src_editor/Editor_CodeBlock.re
+++ b/client/src_editor/Editor_CodeBlock.re
@@ -80,7 +80,7 @@ let make =
                                 ~element=createErrorWidget(content),
                                 ~options=
                                   CodeMirror.LineWidget.options(
-                                    ~coverGutter=true,
+                                    ~coverGutter=false,
                                     ~noHScroll=false,
                                     ~above=false,
                                     ~showIfHidden=false,
@@ -96,7 +96,7 @@ let make =
                                 ~element=createWarningWidget(content),
                                 ~options=
                                   CodeMirror.LineWidget.options(
-                                    ~coverGutter=true,
+                                    ~coverGutter=false,
                                     ~noHScroll=false,
                                     ~above=false,
                                     ~showIfHidden=false,

--- a/client/src_editor/Editor_CodeMirror.re
+++ b/client/src_editor/Editor_CodeMirror.re
@@ -160,9 +160,10 @@ let make =
       };
 
       state.editor := Some(editor);
-      %bs.raw
-      {|window.editor = editor|};
-      ();
+      if (Utils.env != "production") {
+        %bs.raw
+        {|window.editor = editor|};
+      };
     },
   render: ({handle, state: _}) =>
     <div ?className ref=(handle(setDivRef)) />,

--- a/client/src_editor/Editor_Note.css
+++ b/client/src_editor/Editor_Note.css
@@ -41,7 +41,7 @@
   color: rgb(150, 150, 150);
   font-size: var(--f6);
   position: fixed;
-  bottom: var(--space3);
+  bottom: var(--space5);
   left: var(--space3);
   z-index: 1;
 }

--- a/client/src_editor/Editor_Note.re
+++ b/client/src_editor/Editor_Note.re
@@ -37,10 +37,10 @@ let component = ReasonReact.reducerComponent("Editor_Page");
 let make =
     (
       ~blocks,
-      ~userId,
-      ~noteOwner=?,
+      ~noteOwnerId=?,
       ~title="",
       ~noteSaveStatus: NoteSave_Types.noteSaveStatus,
+      ~isEditable,
       ~onSave,
       _children,
     ) => {
@@ -182,6 +182,7 @@ let make =
             placeholder="untitled note"
             value=state.title
             onChange=(event => valueFromEvent(event)->TitleUpdate->send)
+            readOnly=(!isEditable)
           />
         </div>
         <Editor_Blocks
@@ -190,6 +191,7 @@ let make =
             callback => send(RegisterExecuteCallback(callback))
           )
           onUpdate=(blocks => send(BlockUpdate(blocks)))
+          readOnly=(!isEditable)
         />
       </main>
     </>;

--- a/client/src_editor/Editor_Note.re
+++ b/client/src_editor/Editor_Note.re
@@ -48,10 +48,8 @@ let make =
       | NoteSave_Loading => {...state, editorContentStatus: Ec_Saving}
       | NoteSave_Done => {...state, editorContentStatus: Ec_Saved}
       | NoteSave_Error =>
-        /*
-         * TODO: Show global error message
-         */
-        {...state, editorContentStatus: Ec_Dirty}
+        UI_Notification.notify("Save error");
+        {...state, editorContentStatus: Ec_Dirty};
       };
     } else {
       state;

--- a/client/src_editor/Editor_Note.re
+++ b/client/src_editor/Editor_Note.re
@@ -112,35 +112,61 @@ let make =
                         "Run"->str
                       </button>
                  </UI_Balloon>
-                 <UI_Balloon position=Down length=Fit message="Save">
-                   /* switch (saveStatus) {
-                      | Pristine => "Nothing to save (Ctrl+S)"
-                      | Saved => "Saved (Ctrl+S)"
-                      | Saving
-                      | Unsaved => "Save modified changes (Ctrl+S)"
-                      } */
-                   /* switch (saveStatus) {
-                      | Pristine
-                      | Saved
-                      | Saving => true
-                      | Unsaved => false
-                      } */
+                 (
+                   isEditable ?
+                     <UI_Balloon position=Down length=Fit message="Save">
+                       /* switch (saveStatus) {
+                          | Pristine => "Nothing to save (Ctrl+S)"
+                          | Saved => "Saved (Ctrl+S)"
+                          | Saving
+                          | Unsaved => "Save modified changes (Ctrl+S)"
+                          } */
+                       /* switch (saveStatus) {
+                          | Pristine
+                          | Saved
+                          | Saving => true
+                          | Unsaved => false
+                          } */
 
-                     ...<button
-                          disabled=false
-                          className=buttonClassName
-                          onClick=(
-                            _ => {
-                              onSave(~title=state.title, ~data=state.blocks^);
-                              switch (state.executeCallback) {
-                              | None => ()
-                              | Some(callback) => callback()
-                              };
-                            }
-                          )>
-                          <> <Fi.Save /> "Save"->str </>
-                        </button>
-                   </UI_Balloon>
+                         ...<button
+                              disabled=false
+                              className=buttonClassName
+                              onClick=(
+                                _ => {
+                                  onSave(
+                                    ~title=state.title,
+                                    ~data=state.blocks^,
+                                  );
+                                  switch (state.executeCallback) {
+                                  | None => ()
+                                  | Some(callback) => callback()
+                                  };
+                                }
+                              )>
+                              <> <Fi.Save /> "Save"->str </>
+                            </button>
+                       </UI_Balloon> :
+                     <UI_Balloon
+                       position=Down message="Fork this note to edit">
+                       ...<button
+                            disabled=true
+                            className=buttonClassName
+                            onClick=(
+                              _ => {
+                                onSave(
+                                  ~title=state.title,
+                                  ~data=state.blocks^,
+                                );
+                                switch (state.executeCallback) {
+                                | None => ()
+                                | Some(callback) => callback()
+                                };
+                              }
+                            )>
+                            <> <Fi.Save /> "Save"->str </>
+                          </button>
+                     </UI_Balloon>
+                 )
                  /* (
                       isSaving ?
                         <>

--- a/client/src_editor/Editor_Note.re
+++ b/client/src_editor/Editor_Note.re
@@ -2,42 +2,31 @@ Modules.require("./Editor_Note.css");
 open Utils;
 open Editor_Types.Block;
 
+type editorContentStatus =
+  | Ec_Pristine
+  | Ec_Dirty
+  | Ec_Saving
+  | Ec_Saved;
+
 type state = {
   title: string,
-  pristine: bool,
-  dirty: bool,
+  editorContentStatus,
+  noteSaveStatus: ref(NoteSave_Types.noteSaveStatus),
   blocks: ref(array(block)),
-  isSaving: ref(bool),
   executeCallback: option(unit => unit),
 };
+
 type action =
   | TitleUpdate(string)
   | BlockUpdate(array(block))
   | RegisterExecuteCallback(unit => unit);
-
-type saveStatus =
-  | Pristine
-  | Saved
-  | Saving
-  | Unsaved;
-
-let deriveSaveStatus = (~pristine, ~isSaving, ~dirty) =>
-  if (pristine) {
-    Pristine;
-  } else if (isSaving) {
-    Saving;
-  } else if (dirty) {
-    Unsaved;
-  } else {
-    Saved;
-  };
 
 let component = ReasonReact.reducerComponent("Editor_Page");
 
 let make =
     (
       ~blocks,
-      ~noteOwnerId=?,
+      ~noteOwnerId as _=?,
       ~title="",
       ~noteSaveStatus: NoteSave_Types.noteSaveStatus,
       ~isEditable,
@@ -47,44 +36,40 @@ let make =
   ...component,
   initialState: () => {
     title,
-    pristine: true,
-    dirty: false,
+    editorContentStatus: Ec_Pristine,
+    noteSaveStatus: ref(noteSaveStatus),
     blocks: ref(blocks),
-    isSaving: ref(false),
     executeCallback: None,
   },
-  /* willReceiveProps: ({state}) =>
-     if (state.isSaving^ != isSaving) {
-       state.isSaving := isSaving;
-       {...state, dirty: false, pristine: false};
-     } else {
-       state;
-     }, */
+  willReceiveProps: ({state}) =>
+    if (state.noteSaveStatus^ != noteSaveStatus) {
+      state.noteSaveStatus := noteSaveStatus;
+      switch (noteSaveStatus) {
+      | NoteSave_Loading => {...state, editorContentStatus: Ec_Saving}
+      | NoteSave_Done => {...state, editorContentStatus: Ec_Saved}
+      | NoteSave_Error =>
+        /*
+         * TODO: Show global error message
+         */
+        {...state, editorContentStatus: Ec_Dirty}
+      };
+    } else {
+      state;
+    },
   reducer: (action, state) =>
     switch (action) {
     | TitleUpdate(title) =>
-      ReasonReact.Update({...state, pristine: false, dirty: true, title})
+      ReasonReact.Update({...state, title, editorContentStatus: Ec_Dirty})
     | RegisterExecuteCallback(callback) =>
       ReasonReact.Update({...state, executeCallback: Some(callback)})
     | BlockUpdate(blocks) =>
       state.blocks := blocks;
-      ReasonReact.Update({...state, pristine: false, dirty: true});
+      ReasonReact.Update({...state, editorContentStatus: Ec_Dirty});
     },
   render: ({state, send}) => {
-    Js.log(
-      switch (noteSaveStatus) {
-      | NoteSave_Done => "note save done"
-      | NoteSave_Loading => "note save loading"
-      | NoteSave_Error => "note save error"
-      },
-    );
+    let readOnly = !isEditable;
+    let {editorContentStatus} = state;
     <>
-      /* let saveStatus =
-         deriveSaveStatus(
-           ~pristine=state.pristine,
-           ~isSaving,
-           ~dirty=state.dirty,
-         ); */
       <UI_Topbar.WithToolbar>
         ...(
              (~buttonClassName) =>
@@ -113,68 +98,73 @@ let make =
                       </button>
                  </UI_Balloon>
                  (
-                   !isEditable ?
-                     /* aka readOnly */
+                   readOnly ?
                      ReasonReact.null :
-                     <UI_Balloon position=Down length=Fit message="Save">
-                       /* switch (saveStatus) {
-                          | Pristine => "Nothing to save (Ctrl+S)"
-                          | Saved => "Saved (Ctrl+S)"
-                          | Saving
-                          | Unsaved => "Save modified changes (Ctrl+S)"
-                          } */
-                       /* switch (saveStatus) {
-                          | Pristine
-                          | Saved
-                          | Saving => true
-                          | Unsaved => false
-                          } */
-
-                         ...<button
-                              disabled=false
-                              className=buttonClassName
-                              onClick=(
-                                _ => {
-                                  onSave(
-                                    ~title=state.title,
-                                    ~data=state.blocks^,
-                                  );
-                                  switch (state.executeCallback) {
-                                  | None => ()
-                                  | Some(callback) => callback()
-                                  };
-                                }
-                              )>
-                              <> <Fi.Save /> "Save"->str </>
-                            </button>
-                       </UI_Balloon>
+                     <UI_Balloon
+                       position=Down
+                       length=Fit
+                       message=(
+                         switch (editorContentStatus) {
+                         | Ec_Saving => "Saving...(Ctrl+S)"
+                         | Ec_Saved => "Saved (Ctrl+S)"
+                         | Ec_Pristine => "Nothing to save (Ctrl+S)"
+                         | Ec_Dirty => "Save modified changes (Ctrl+S)"
+                         }
+                       )>
+                       ...<button
+                            disabled=(
+                              switch (editorContentStatus) {
+                              | Ec_Saving
+                              | Ec_Saved
+                              | Ec_Pristine => true
+                              | Ec_Dirty => false
+                              }
+                            )
+                            className=buttonClassName
+                            onClick=(
+                              _ => {
+                                onSave(
+                                  ~title=state.title,
+                                  ~data=state.blocks^,
+                                );
+                                switch (state.executeCallback) {
+                                | None => ()
+                                | Some(callback) => callback()
+                                };
+                              }
+                            )>
+                            (
+                              switch (editorContentStatus) {
+                              | Ec_Saving =>
+                                <>
+                                  <Fi.Loader
+                                    className="EditorNav__button--spin"
+                                  />
+                                  "Saving"->str
+                                </>
+                              | Ec_Saved
+                              | Ec_Dirty
+                              | Ec_Pristine => <> <Fi.Save /> "Save"->str </>
+                              }
+                            )
+                          </button>
+                     </UI_Balloon>
                  )
-                 /* (
-                      isSaving ?
-                        <>
-                          <Fi.Loader
-                            className="EditorNav__button--spin"
-                          />
-                          "Saving"->str
-                        </> :
-                        <> <Fi.Save /> "Save"->str </>
-                    ) */
                </>
            )
       </UI_Topbar.WithToolbar>
-      <div
-        className="EditorNote__saveStatus"
-        /* {
-             let status =
-               switch (saveStatus) {
-               | Pristine => ""
-               | Saved => "Saved"
-               | Saving => "Saving"
-               | Unsaved => "Unsaved"
-               };
-             status->str;
-           } */
-      />
+      <div className="EditorNote__saveStatus">
+        {
+          let status =
+            switch (editorContentStatus) {
+            | Ec_Pristine => ""
+            | Ec_Saved => "Saved"
+            | Ec_Saving => "Saving"
+            | Ec_Dirty => "Unsaved"
+            };
+          status->str;
+        }
+      </div>
       <main className="EditorNote">
         <Helmet>
           <title>
@@ -190,7 +180,7 @@ let make =
             placeholder="untitled note"
             value=state.title
             onChange=(event => valueFromEvent(event)->TitleUpdate->send)
-            readOnly=(!isEditable)
+            readOnly
           />
         </div>
         <Editor_Blocks
@@ -199,7 +189,7 @@ let make =
             callback => send(RegisterExecuteCallback(callback))
           )
           onUpdate=(blocks => send(BlockUpdate(blocks)))
-          readOnly=(!isEditable)
+          readOnly
         />
       </main>
     </>;

--- a/client/src_editor/Editor_Note.re
+++ b/client/src_editor/Editor_Note.re
@@ -113,7 +113,9 @@ let make =
                       </button>
                  </UI_Balloon>
                  (
-                   isEditable ?
+                   !isEditable ?
+                     /* aka readOnly */
+                     ReasonReact.null :
                      <UI_Balloon position=Down length=Fit message="Save">
                        /* switch (saveStatus) {
                           | Pristine => "Nothing to save (Ctrl+S)"
@@ -145,27 +147,7 @@ let make =
                               )>
                               <> <Fi.Save /> "Save"->str </>
                             </button>
-                       </UI_Balloon> :
-                     <UI_Balloon
-                       position=Down message="Fork this note to edit">
-                       ...<button
-                            disabled=true
-                            className=buttonClassName
-                            onClick=(
-                              _ => {
-                                onSave(
-                                  ~title=state.title,
-                                  ~data=state.blocks^,
-                                );
-                                switch (state.executeCallback) {
-                                | None => ()
-                                | Some(callback) => callback()
-                                };
-                              }
-                            )>
-                            <> <Fi.Save /> "Save"->str </>
-                          </button>
-                     </UI_Balloon>
+                       </UI_Balloon>
                  )
                  /* (
                       isSaving ?

--- a/client/src_editor/Editor_Note.re
+++ b/client/src_editor/Editor_Note.re
@@ -34,23 +34,32 @@ let deriveSaveStatus = (~pristine, ~isSaving, ~dirty) =>
 
 let component = ReasonReact.reducerComponent("Editor_Page");
 
-let make = (~blocks, ~title="", ~loading as isSaving, ~onSave, _children) => {
+let make =
+    (
+      ~blocks,
+      ~userId,
+      ~noteOwner=?,
+      ~title="",
+      ~noteSaveStatus: NoteSave_Types.noteSaveStatus,
+      ~onSave,
+      _children,
+    ) => {
   ...component,
   initialState: () => {
     title,
     pristine: true,
     dirty: false,
     blocks: ref(blocks),
-    isSaving: ref(isSaving),
+    isSaving: ref(false),
     executeCallback: None,
   },
-  willReceiveProps: ({state}) =>
-    if (state.isSaving^ != isSaving) {
-      state.isSaving := isSaving;
-      {...state, dirty: false, pristine: false};
-    } else {
-      state;
-    },
+  /* willReceiveProps: ({state}) =>
+     if (state.isSaving^ != isSaving) {
+       state.isSaving := isSaving;
+       {...state, dirty: false, pristine: false};
+     } else {
+       state;
+     }, */
   reducer: (action, state) =>
     switch (action) {
     | TitleUpdate(title) =>
@@ -62,13 +71,20 @@ let make = (~blocks, ~title="", ~loading as isSaving, ~onSave, _children) => {
       ReasonReact.Update({...state, pristine: false, dirty: true});
     },
   render: ({state, send}) => {
-    let saveStatus =
-      deriveSaveStatus(
-        ~pristine=state.pristine,
-        ~isSaving,
-        ~dirty=state.dirty,
-      );
+    Js.log(
+      switch (noteSaveStatus) {
+      | NoteSave_Done => "note save done"
+      | NoteSave_Loading => "note save loading"
+      | NoteSave_Error => "note save error"
+      },
+    );
     <>
+      /* let saveStatus =
+         deriveSaveStatus(
+           ~pristine=state.pristine,
+           ~isSaving,
+           ~dirty=state.dirty,
+         ); */
       <UI_Topbar.WithToolbar>
         ...(
              (~buttonClassName) =>
@@ -96,61 +112,61 @@ let make = (~blocks, ~title="", ~loading as isSaving, ~onSave, _children) => {
                         "Run"->str
                       </button>
                  </UI_Balloon>
-                 <UI_Balloon
-                   position=Down
-                   length=Fit
-                   message=(
-                     switch (saveStatus) {
-                     | Pristine => "Nothing to save (Ctrl+S)"
-                     | Saved => "Saved (Ctrl+S)"
-                     | Saving
-                     | Unsaved => "Save modified changes (Ctrl+S)"
-                     }
-                   )>
-                   ...<button
-                        disabled=(
-                          switch (saveStatus) {
-                          | Pristine
-                          | Saved
-                          | Saving => true
-                          | Unsaved => false
-                          }
-                        )
-                        className=buttonClassName
-                        onClick=(
-                          _ => {
-                            onSave(~title=state.title, ~data=state.blocks^);
-                            switch (state.executeCallback) {
-                            | None => ()
-                            | Some(callback) => callback()
-                            };
-                          }
-                        )>
-                        (
-                          isSaving ?
-                            <>
-                              <Fi.Loader className="EditorNav__button--spin" />
-                              "Saving"->str
-                            </> :
-                            <> <Fi.Save /> "Save"->str </>
-                        )
-                      </button>
-                 </UI_Balloon>
+                 <UI_Balloon position=Down length=Fit message="Save">
+                   /* switch (saveStatus) {
+                      | Pristine => "Nothing to save (Ctrl+S)"
+                      | Saved => "Saved (Ctrl+S)"
+                      | Saving
+                      | Unsaved => "Save modified changes (Ctrl+S)"
+                      } */
+                   /* switch (saveStatus) {
+                      | Pristine
+                      | Saved
+                      | Saving => true
+                      | Unsaved => false
+                      } */
+
+                     ...<button
+                          disabled=false
+                          className=buttonClassName
+                          onClick=(
+                            _ => {
+                              onSave(~title=state.title, ~data=state.blocks^);
+                              switch (state.executeCallback) {
+                              | None => ()
+                              | Some(callback) => callback()
+                              };
+                            }
+                          )>
+                          <> <Fi.Save /> "Save"->str </>
+                        </button>
+                   </UI_Balloon>
+                 /* (
+                      isSaving ?
+                        <>
+                          <Fi.Loader
+                            className="EditorNav__button--spin"
+                          />
+                          "Saving"->str
+                        </> :
+                        <> <Fi.Save /> "Save"->str </>
+                    ) */
                </>
            )
       </UI_Topbar.WithToolbar>
-      <div className="EditorNote__saveStatus">
-        {
-          let status =
-            switch (saveStatus) {
-            | Pristine => ""
-            | Saved => "Saved"
-            | Saving => "Saving"
-            | Unsaved => "Unsaved"
-            };
-          status->str;
-        }
-      </div>
+      <div
+        className="EditorNote__saveStatus"
+        /* {
+             let status =
+               switch (saveStatus) {
+               | Pristine => ""
+               | Saved => "Saved"
+               | Saving => "Saving"
+               | Unsaved => "Unsaved"
+               };
+             status->str;
+           } */
+      />
       <main className="EditorNote">
         <Helmet>
           <title>

--- a/client/src_editor/Editor_Note_Loader.re
+++ b/client/src_editor/Editor_Note_Loader.re
@@ -26,8 +26,9 @@ let make = _children => {
   render: _self =>
     <Editor_Note
       blocks
+      userId=""
       title="ReasonML playground"
       onSave=((~title as _, ~data as _) => ())
-      loading=false
+      noteSaveStatus=NoteSave_Types.NoteSave_Done
     />,
 };

--- a/client/src_editor/Editor_Note_Loader.re
+++ b/client/src_editor/Editor_Note_Loader.re
@@ -26,7 +26,7 @@ let make = _children => {
   render: _self =>
     <Editor_Note
       blocks
-      userId=""
+      isEditable=true
       title="ReasonML playground"
       onSave=((~title as _, ~data as _) => ())
       noteSaveStatus=NoteSave_Types.NoteSave_Done

--- a/client/src_editor/Editor_TextBlock.re
+++ b/client/src_editor/Editor_TextBlock.re
@@ -17,6 +17,7 @@ let make =
       ~onBlur=?,
       ~onBlockUp=?,
       ~onBlockDown=?,
+      ~readOnly=?,
       _children,
     )
     : ReasonReact.component(state, _, unit) => {
@@ -45,6 +46,7 @@ let make =
           ~lineNumbers=false,
           ~viewportMargin=infinity,
           ~lineWrapping=true,
+          ~readOnly?,
           (),
         )
       )

--- a/client/src_editor/createLineWidget.css
+++ b/client/src_editor/createLineWidget.css
@@ -6,26 +6,17 @@
   --lint-widget-main-color: #9f6000;
   --lint-widget-background-color: #feefb3;
 }
+
 .widget__lint .widget__lint--wrapper {
   background-color: var(--lint-widget-background-color);
   color: var(--lint-widget-main-color);
   overflow: hidden;
   position: relative;
   min-height: 2em;
-  margin-left: 24px;
-  border-left: 6px solid var(--lint-widget-main-color);
+  margin-left: -5px;
+  border-left: 4px solid var(--lint-widget-main-color);
   display: flex;
   align-items: center;
-}
-
-.widget__lint .widget__lint--wrapper::before {
-  content: " ";
-  position: absolute;
-  top: 0;
-  left: 1px;
-  right: 0;
-  bottom: 0;
-  border-left: 2px solid var(--lint-widget-main-color);
 }
 
 .widget__lint .wrapper__link--content {

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -76,9 +76,17 @@ const base = {
               ident: "postcss",
               plugins: () => [
                 postcssPresetEnv({
-                  stage: 2,
+                  stage: 3,
                   features: {
                     "nesting-rules": true,
+                    "custom-media-queries": {
+                      extensions: {
+                        "--sm": "screen and (min-width: 35.5rem)",
+                        "--md": "screen and (min-width: 48rem)",
+                        "--lg": "screen and (min-width: 64rem)",
+                        "--xl": "screen and (min-width: 80rem)",
+                      },
+                    },
                   },
                 }),
               ],

--- a/server/auth/server.js
+++ b/server/auth/server.js
@@ -110,15 +110,10 @@ app.get("/auth/webhook", (req, res) => {
   const token = jwtTokenFromHeader(req);
 
   if (!token) {
-    let returnValues = {
+    res.json({
       "X-Hasura-Role": "public",
-    };
-    if (req.header("X-Hasura-Edit-Token")) {
-      returnValues = Object.assign(returnValues, {
-        "X-Hasura-Edit-Token": req.header("X-Hasura-Edit-Token"),
-      });
-    }
-    res.json(returnValues);
+      "X-Hasura-Edit-Token": req.header("X-Hasura-Edit-Token") || "",
+    });
     return;
   }
 
@@ -130,6 +125,7 @@ app.get("/auth/webhook", (req, res) => {
       res.json({
         "X-Hasura-Role": result.role,
         "X-Hasura-User-Id": result.userId,
+        "X-Hasura-Edit-Token": "",
       });
       return;
     }

--- a/server/auth/server.js
+++ b/server/auth/server.js
@@ -110,9 +110,15 @@ app.get("/auth/webhook", (req, res) => {
   const token = jwtTokenFromHeader(req);
 
   if (!token) {
-    res.json({
+    let returnValues = {
       "X-Hasura-Role": "public",
-    });
+    };
+    if (req.header("X-Hasura-Edit-Token")) {
+      returnValues = Object.assign(returnValues, {
+        "X-Hasura-Edit-Token": req.header("X-Hasura-Edit-Token"),
+      });
+    }
+    res.json(returnValues);
     return;
   }
 

--- a/server/hasura/migrations/metadata.yaml
+++ b/server/hasura/migrations/metadata.yaml
@@ -1,252 +1,274 @@
 query_templates: []
 tables:
-- array_relationships: []
-  delete_permissions: []
-  insert_permissions: []
-  object_relationships:
-  - comment: null
-    name: note
-    using:
-      foreign_key_constraint_on: note_id
-  select_permissions:
-  - comment: null
-    permission:
-      columns:
-      - note_id
-      - created_at
-      - title
-      - data
-      filter: {}
-    role: public
-  - comment: null
-    permission:
-      columns:
-      - data
-      - note_id
-      - created_at
-      - title
-      filter: {}
-    role: user
-  table: note_revision
-  update_permissions: []
-- array_relationships: []
-  delete_permissions: []
-  insert_permissions: []
-  object_relationships: []
-  select_permissions:
-  - comment: null
-    permission:
-      columns:
-      - user_identity_type
-      filter: {}
-    role: auth_service
-  table: user_identity_type
-  update_permissions: []
-- array_relationships: []
-  delete_permissions: []
-  insert_permissions:
-  - comment: null
-    permission:
-      allow_upsert: false
-      check: {}
-    role: public
-  object_relationships: []
-  select_permissions: []
-  table: note_edit_token
-  update_permissions: []
-- array_relationships: []
-  delete_permissions: []
-  insert_permissions: []
-  object_relationships: []
-  select_permissions:
-  - comment: null
-    permission:
-      columns:
-      - id
-      - username
-      - name
-      - avatar
-      - created_at
-      - updated_at
-      filter: {}
-    role: user
-  - comment: null
-    permission:
-      columns:
-      - created_at
-      - updated_at
-      - id
-      - username
-      - name
-      - avatar
-      filter: {}
-    role: public
-  table: user_public
-  update_permissions: []
-- array_relationships: []
-  delete_permissions: []
-  insert_permissions:
-  - comment: null
-    permission:
-      allow_upsert: true
-      check: {}
-    role: auth_service
-  object_relationships:
-  - comment: null
-    name: user
-    using:
-      foreign_key_constraint_on: user_id
-  select_permissions:
-  - comment: null
-    permission:
-      columns:
-      - identity_type
-      - user_id
-      - data
-      - identity_id
-      filter: {}
-    role: auth_service
-  table: user_identity
-  update_permissions:
-  - comment: null
-    permission:
-      columns:
-      - identity_type
-      - user_id
-      - data
-      - identity_id
-      filter: {}
-    role: auth_service
-- array_relationships:
-  - comment: null
-    name: notes
-    using:
-      foreign_key_constraint_on:
-        column: user_id
-        table: note
-  - comment: null
-    name: identities
-    using:
-      foreign_key_constraint_on:
-        column: user_id
-        table: user_identity
-  delete_permissions: []
-  insert_permissions:
-  - comment: null
-    permission:
-      allow_upsert: false
-      check: {}
-    role: auth_service
-  object_relationships: []
-  select_permissions:
-  - comment: null
-    permission:
-      columns:
-      - id
-      - username
-      - name
-      - email
-      - avatar
-      - created_at
-      - updated_at
-      filter: {}
-    role: auth_service
-  table: user
-  update_permissions:
-  - comment: null
-    permission:
-      columns:
-      - username
-      - name
-      - email
-      - avatar
-      - created_at
-      - updated_at
-      - id
-      filter: {}
-    role: auth_service
-- array_relationships:
-  - comment: null
-    name: revisions
-    using:
-      foreign_key_constraint_on:
-        column: note_id
-        table: note_revision
-  - comment: null
-    name: edit_tokens
-    using:
-      foreign_key_constraint_on:
-        column: note_id
-        table: note_edit_token
-  delete_permissions: []
-  insert_permissions:
-  - comment: null
-    permission:
-      allow_upsert: false
-      check:
-        user_id:
-          _eq: X-HASURA-USER-ID
-    role: user
-  - comment: null
-    permission:
-      allow_upsert: false
-      check:
-        user_id:
-          _eq: anonymous
-    role: public
-  object_relationships:
-  - comment: null
-    name: user
-    using:
-      foreign_key_constraint_on: user_id
-  - comment: null
-    name: owner
-    using:
-      manual_configuration:
-        column_mapping:
-          user_id: id
-        remote_table: user_public
-  select_permissions:
-  - comment: null
-    permission:
-      columns:
-      - id
-      - user_id
-      - title
-      - data
-      - created_at
-      - updated_at
-      filter: {}
-    role: public
-  - comment: null
-    permission:
-      columns:
-      - updated_at
-      - user_id
-      - id
-      - title
-      - data
-      - created_at
-      filter: {}
-    role: user
-  table: note
-  update_permissions:
-  - comment: null
-    permission:
-      columns:
-      - data
-      - title
-      filter:
-        user_id:
-          _eq: X-HASURA-USER-ID
-    role: user
-  - comment: null
-    permission:
-      columns:
-      - data
-      - title
-      filter:
-        edit_tokens:
-          token:
-            _eq: X-Hasura-Edit-Token
-    role: public
+  - array_relationships: []
+    delete_permissions: []
+    insert_permissions: []
+    object_relationships:
+      - comment: null
+        name: note
+        using:
+          foreign_key_constraint_on: note_id
+    select_permissions:
+      - comment: null
+        permission:
+          columns:
+            - note_id
+            - created_at
+            - title
+            - data
+          filter: {}
+        role: public
+      - comment: null
+        permission:
+          columns:
+            - data
+            - note_id
+            - created_at
+            - title
+          filter: {}
+        role: user
+    table: note_revision
+    update_permissions: []
+  - array_relationships: []
+    delete_permissions: []
+    insert_permissions: []
+    object_relationships: []
+    select_permissions:
+      - comment: null
+        permission:
+          columns:
+            - user_identity_type
+          filter: {}
+        role: auth_service
+    table: user_identity_type
+    update_permissions: []
+  - array_relationships: []
+    delete_permissions: []
+    insert_permissions:
+      - comment: null
+        permission:
+          allow_upsert: false
+          check: {}
+        role: public
+    object_relationships:
+      - comment: null
+        name: note
+        using:
+          foreign_key_constraint_on: note_id
+    select_permissions:
+      - comment: null
+        permission:
+          columns:
+            - note_id
+          filter:
+            token:
+              _eq: X-Hasura-Edit-Token
+          limit: 30
+        role: public
+      - comment: null
+        permission:
+          columns:
+            - note_id
+          filter:
+            token:
+              _eq: X-Hasura-Edit-Token
+          limit: 30
+        role: user
+    table: note_edit_token
+    update_permissions: []
+  - array_relationships: []
+    delete_permissions: []
+    insert_permissions: []
+    object_relationships: []
+    select_permissions:
+      - comment: null
+        permission:
+          columns:
+            - id
+            - username
+            - name
+            - avatar
+            - created_at
+            - updated_at
+          filter: {}
+        role: user
+      - comment: null
+        permission:
+          columns:
+            - created_at
+            - updated_at
+            - id
+            - username
+            - name
+            - avatar
+          filter: {}
+        role: public
+    table: user_public
+    update_permissions: []
+  - array_relationships: []
+    delete_permissions: []
+    insert_permissions:
+      - comment: null
+        permission:
+          allow_upsert: true
+          check: {}
+        role: auth_service
+    object_relationships:
+      - comment: null
+        name: user
+        using:
+          foreign_key_constraint_on: user_id
+    select_permissions:
+      - comment: null
+        permission:
+          columns:
+            - identity_type
+            - user_id
+            - data
+            - identity_id
+          filter: {}
+        role: auth_service
+    table: user_identity
+    update_permissions:
+      - comment: null
+        permission:
+          columns:
+            - identity_type
+            - user_id
+            - data
+            - identity_id
+          filter: {}
+        role: auth_service
+  - array_relationships:
+      - comment: null
+        name: notes
+        using:
+          foreign_key_constraint_on:
+            column: user_id
+            table: note
+      - comment: null
+        name: identities
+        using:
+          foreign_key_constraint_on:
+            column: user_id
+            table: user_identity
+    delete_permissions: []
+    insert_permissions:
+      - comment: null
+        permission:
+          allow_upsert: false
+          check: {}
+        role: auth_service
+    object_relationships: []
+    select_permissions:
+      - comment: null
+        permission:
+          columns:
+            - id
+            - username
+            - name
+            - email
+            - avatar
+            - created_at
+            - updated_at
+          filter: {}
+        role: auth_service
+    table: user
+    update_permissions:
+      - comment: null
+        permission:
+          columns:
+            - username
+            - name
+            - email
+            - avatar
+            - created_at
+            - updated_at
+            - id
+          filter: {}
+        role: auth_service
+  - array_relationships:
+      - comment: null
+        name: revisions
+        using:
+          foreign_key_constraint_on:
+            column: note_id
+            table: note_revision
+      - comment: null
+        name: edit_tokens
+        using:
+          foreign_key_constraint_on:
+            column: note_id
+            table: note_edit_token
+    delete_permissions: []
+    insert_permissions:
+      - comment: null
+        permission:
+          allow_upsert: false
+          check:
+            user_id:
+              _eq: X-HASURA-USER-ID
+        role: user
+      - comment: null
+        permission:
+          allow_upsert: false
+          check:
+            user_id:
+              _eq: anonymous
+        role: public
+    object_relationships:
+      - comment: null
+        name: user
+        using:
+          foreign_key_constraint_on: user_id
+      - comment: null
+        name: owner
+        using:
+          manual_configuration:
+            column_mapping:
+              user_id: id
+            remote_table: user_public
+    select_permissions:
+      - comment: null
+        permission:
+          columns:
+            - id
+            - user_id
+            - title
+            - data
+            - created_at
+            - updated_at
+          filter: {}
+        role: public
+      - comment: null
+        permission:
+          columns:
+            - updated_at
+            - user_id
+            - id
+            - title
+            - data
+            - created_at
+          filter: {}
+        role: user
+    table: note
+    update_permissions:
+      - comment: null
+        permission:
+          columns:
+            - data
+            - title
+          filter:
+            user_id:
+              _eq: X-HASURA-USER-ID
+        role: user
+      - comment: null
+        permission:
+          columns:
+            - data
+            - title
+          filter:
+            edit_tokens:
+              token:
+                _eq: X-Hasura-Edit-Token
+        role: public

--- a/server/hasura/migrations/metadata.yaml
+++ b/server/hasura/migrations/metadata.yaml
@@ -44,6 +44,18 @@ tables:
   update_permissions: []
 - array_relationships: []
   delete_permissions: []
+  insert_permissions:
+  - comment: null
+    permission:
+      allow_upsert: false
+      check: {}
+    role: public
+  object_relationships: []
+  select_permissions: []
+  table: note_edit_token
+  update_permissions: []
+- array_relationships: []
+  delete_permissions: []
   insert_permissions: []
   object_relationships: []
   select_permissions:
@@ -160,6 +172,12 @@ tables:
       foreign_key_constraint_on:
         column: note_id
         table: note_revision
+  - comment: null
+    name: edit_tokens
+    using:
+      foreign_key_constraint_on:
+        column: note_id
+        table: note_edit_token
   delete_permissions: []
   insert_permissions:
   - comment: null
@@ -222,3 +240,13 @@ tables:
         user_id:
           _eq: X-HASURA-USER-ID
     role: user
+  - comment: null
+    permission:
+      columns:
+      - data
+      - title
+      filter:
+        edit_tokens:
+          token:
+            _eq: X-Hasura-Edit-Token
+    role: public

--- a/server/schema/migrations/20180809163053_add_edit_token.js
+++ b/server/schema/migrations/20180809163053_add_edit_token.js
@@ -1,0 +1,16 @@
+exports.up = function(knex, Promise) {
+  return knex.schema.createTable("note_edit_token", function(table) {
+    table.string("token", 22).notNullable();
+    table
+      .string("note_id", 22)
+      .notNullable()
+      .references("note.id");
+    table.primary(["token", "note_id"]);
+  });
+};
+
+exports.down = function(knex, Promise) {
+  return knex.raw(`
+    DROP TABLE IF EXISTS "note_edit_token" CASCADE;
+  `);
+};


### PR DESCRIPTION
This is a huge PR refactoring the whole note saving login. 

Features:

1. Anonymous editing of newly created content
This is done by saving a new localstorage entry named `rtop:editToken` . This token be sent with every request and on new note creation to set a token on `note_edit_token`

2. Handling saving permission client side
Editors will be put into readonly mode, no save button when you don't have the permission (either as note owner or incorrect `editToken`)

Closes: #57 
Closes: #61 

TODO: 

- [x] Fix save status indication (Pristine, Saving, Saved, Error, ...)
- [x] Display global error when (well there is an error)
- [x] Read only mode shouldn't allow manipulating blocks (add, delete)